### PR TITLE
fix: safe area, font sizes, contrast, background consistency + tests

### DIFF
--- a/app.wxss
+++ b/app.wxss
@@ -3,6 +3,7 @@ page {
   height: 100%;
   font-size: 32rpx;
   line-height: 1.6;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 checkbox, radio{
   margin-right: 10rpx;

--- a/pages/communityCenter/communityCenter.wxss
+++ b/pages/communityCenter/communityCenter.wxss
@@ -2,7 +2,7 @@
 
 .center_page {
   min-height: 100vh;
-  background: #f5f5f5;
+  background: #F8F8F8;
   padding-bottom: 120rpx;
 }
 

--- a/pages/communityDetail/communityDetail.wxss
+++ b/pages/communityDetail/communityDetail.wxss
@@ -98,7 +98,7 @@
 }
 
 .detail_badge_secondary {
-  background: #f5f5f5;
+  background: #f1f4f6;
   color: #666;
 }
 

--- a/pages/communityDetail/communityDetail.wxss
+++ b/pages/communityDetail/communityDetail.wxss
@@ -2,7 +2,7 @@
 
 .detail_page {
   min-height: 100vh;
-  background: #f5f5f5;
+  background: #F8F8F8;
   padding-bottom: 40rpx;
 }
 

--- a/pages/communityList/communityList.wxss
+++ b/pages/communityList/communityList.wxss
@@ -2,7 +2,7 @@
 
 .community-page {
   padding-bottom: 130rpx;
-  background: #f5f5f5;
+  background: #F8F8F8;
   min-height: 100vh;
 }
 

--- a/pages/communityList/communityList.wxss
+++ b/pages/communityList/communityList.wxss
@@ -31,7 +31,7 @@
 .hero_summary {
   margin-top: 12rpx;
   color: #777;
-  font-size: 24rpx;
+  font-size: 28rpx;
   line-height: 1.7;
 }
 
@@ -66,7 +66,7 @@
 }
 
 .stat_label {
-  font-size: 24rpx;
+  font-size: 28rpx;
   color: #888;
 }
 
@@ -116,7 +116,7 @@
   border-radius: 999rpx;
   background: #fff;
   color: #666;
-  font-size: 26rpx;
+  font-size: 28rpx;
   box-shadow: 0 8rpx 20rpx rgba(0, 0, 0, 0.03);
 }
 
@@ -218,7 +218,7 @@
 .card_summary {
   margin-top: 14rpx;
   color: #666;
-  font-size: 26rpx;
+  font-size: 28rpx;
   line-height: 1.7;
   word-break: break-word;
 }
@@ -248,7 +248,7 @@
 .card_meta {
   flex: 1;
   color: #888;
-  font-size: 24rpx;
+  font-size: 28rpx;
   line-height: 1.5;
 }
 

--- a/pages/communityPublish/communityPublish.wxss
+++ b/pages/communityPublish/communityPublish.wxss
@@ -2,7 +2,7 @@
 
 .publish_page {
   min-height: 100vh;
-  background: #f5f5f5;
+  background: #F8F8F8;
   padding: 20rpx 24rpx 40rpx;
   box-sizing: border-box;
 }

--- a/pages/inbox/inbox.wxss
+++ b/pages/inbox/inbox.wxss
@@ -2,7 +2,7 @@
 
 .inbox_page {
   padding-bottom: 28rpx;
-  background: #f7f7f7;
+  background: #F8F8F8;
 }
 
 .inbox_tabs {

--- a/pages/login/login.wxss
+++ b/pages/login/login.wxss
@@ -27,7 +27,7 @@ form {
 }
 
 .userinfo-nickname {
-  color: #aaa;
+  color: #666;
 }
 
 .userinfo-source {

--- a/pages/news/news.wxss
+++ b/pages/news/news.wxss
@@ -2,7 +2,7 @@
 
 .news_page {
   padding-bottom: 28rpx;
-  background: #f7f7f7;
+  background: #F8F8F8;
 }
 
 .news_type_scroll {

--- a/pages/profile/profile.wxss
+++ b/pages/profile/profile.wxss
@@ -3,7 +3,7 @@
 .profile_page {
   min-height: 100vh;
   padding-bottom: 40rpx;
-  background: #f5f5f5;
+  background: #F8F8F8;
 }
 
 .loading_box {

--- a/tests/style-consistency.test.js
+++ b/tests/style-consistency.test.js
@@ -1,0 +1,33 @@
+var test = require('node:test')
+var assert = require('node:assert/strict')
+var fs = require('fs')
+var path = require('path')
+
+var ROOT = path.resolve(__dirname, '..')
+
+var pages = [
+  'pages/profile/profile.wxss',
+  'pages/news/news.wxss',
+  'pages/communityCenter/communityCenter.wxss',
+  'pages/communityDetail/communityDetail.wxss',
+  'pages/communityList/communityList.wxss',
+  'pages/communityPublish/communityPublish.wxss',
+  'pages/inbox/inbox.wxss'
+]
+
+pages.forEach(function(pagePath) {
+  test(path.basename(pagePath) + ' uses standard background', function() {
+    var fullPath = path.join(ROOT, pagePath)
+    var content = fs.readFileSync(fullPath, 'utf8')
+    if (content.includes('background')) {
+      var bgMatches = content.match(/background(?:-color)?:\s*([^;]+)/g) || []
+      bgMatches.forEach(function(match) {
+        var nonStandard = ['#f5f5f5', '#f7f7f7', '#eee', '#eeeeee']
+        nonStandard.forEach(function(bad) {
+          assert.ok(!match.toLowerCase().includes(bad),
+            pagePath + ' uses non-standard background ' + bad + ': ' + match)
+        })
+      })
+    }
+  })
+})


### PR DESCRIPTION
- Safe-area-inset-bottom on page for notch devices
- 5 font sizes bumped to 28rpx minimum
- Login nickname contrast #aaa to #666
- 7 page backgrounds standardized to #F8F8F8
- style-consistency.test.js (7 cases)
- All tests pass