### PR TITLE
feat: dark mode with CSS variables and Appearance page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@
 - 教室查询
 - 图书馆
 - 校园卡
+- 校园卡充值
+- 校园卡挂失
+- 电费查询
 - 数据查询
 - 教学评价
+- 校园黄页
 
 ### 校园生活
 
@@ -27,47 +31,93 @@
 - 校园话题
 - 拍好校园
 
-### 信息通知
+### 资讯信息
 
 - 新闻通知
+- 系统通知公告
+- 互动消息
 
 ### 个人中心
 
-- 个人资料
+- 个人资料展示与编辑
 - 头像管理
+- 界面和外观（主题切换、字体大小、语言）
 - 设置
 - 退出登录
 
 ## 技术栈
 
-- 微信小程序
+- 微信小程序原生框架
 - WeUI
 - Promise 风格服务层
+- CSS 变量主题系统（亮色/暗色）
 - `mock` / `remote` 双数据源
+- i18n 国际化（6 语言）
 
 ## 工程结构
 
 ```text
 GdeiAssistant-WechatApp/
-├── pages/
+├── pages/                 # 页面模块（27 个页面）
 ├── services/
-│   ├── apis/
-│   ├── auth.js
-│   ├── endpoints.js
-│   ├── request.js
-│   └── upload.js
-├── mock/
-├── constants/
-├── config/
-├── utils/
-└── common/lib/weui.wxss
+│   ├── apis/              # 按业务拆分的接口模块
+│   ├── auth.js            # 登录态管理
+│   ├── data-source.js     # mock/remote 切换
+│   ├── endpoints.js       # 接口路径定义
+│   ├── request.js         # 统一请求封装
+│   ├── response.js        # 响应归一化
+│   └── upload.js          # 文件上传
+├── mock/                  # 本地模拟数据
+├── constants/             # 业务常量
+├── config/                # 环境配置
+├── utils/                 # 工具函数（i18n、主题）
+├── styles/                # 全局主题变量
+├── locales/               # 国际化语言文件（6 语言）
+├── scripts/               # 构建辅助脚本
+└── common/lib/weui.wxss   # WeUI 样式库
 ```
 
-## 数据源与资料配置
+## 架构说明
+
+### 1. 数据源模式
+
+项目支持两种数据源：
 
 - `remote`：请求真实后端接口
 - `mock`：使用本地模拟数据
-- 个人资料地区数据同步自后端仓库 `location.xml`
+
+切换入口位于设置页，切换后即时生效。
+
+当前 mock 登录账号：
+
+- 用户名：`gdeiassistant`
+- 密码：`gdeiassistant`
+
+### 2. 登录态管理
+
+登录链路由以下模块协作完成：
+
+- `auth.js`：Session Token 的存取、验证与清除
+- `request.js`：统一注入鉴权 Header，处理 401 失效
+- `response.js`：响应格式归一化，适配多种后端返回结构
+
+### 3. 网络层
+
+网络层基于 `wx.request`，统一负责：
+
+- 请求构建与 Header 注入
+- Bearer Token 注入
+- 加载状态 UI 管理
+- Mock 模式分发
+- 401 与登录失效处理
+
+### 4. 主题系统
+
+应用支持亮色/暗色主题切换，基于 CSS 变量实现：
+
+- `styles/theme.wxss`：定义亮色与暗色两套 CSS 变量
+- `utils/theme.js`：主题管理工具，支持跟随系统、手动切换、持久化存储
+- 所有页面通过 `themeClass` 动态绑定主题
 
 ## 运行环境
 
@@ -90,11 +140,18 @@ GdeiAssistant-WechatApp/
 
 ## Mock 模式说明
 
-- 登录页或设置页可切换 `mock` 数据源
+调试环境默认支持 `mock` 数据源。
+
+当前 mock 登录账号：
+
 - 用户名：`gdeiassistant`
 - 密码：`gdeiassistant`
 
+设置页可切换 `mock` / `remote` 数据源，切换后即时生效。
+
 ## 后端接口位置
+
+本项目对应的后端仓库为：
 
 - GitHub：`https://github.com/GdeiAssistant/GdeiAssistant`
 
@@ -102,6 +159,11 @@ GdeiAssistant-WechatApp/
 
 本项目采用 [Apache License 2.0](LICENSE.md) 开源协议。
 
+你可以在遵守协议条款的前提下使用、修改和分发本项目代码。
+
 ## 免责声明
 
-本项目仅用于学习与研究用途。
+1. 本项目为校园场景应用客户端，功能和数据能力以学校实际开放范围、后端接口能力及账号权限为准。
+2. 仓库中的 `mock` 数据仅用于本地开发和界面联调，不代表真实校园业务数据。
+3. 本项目不对因第三方服务异常、学校系统调整、网络问题或接口变更导致的功能不可用承担责任。
+4. 使用者在接入真实后端或部署衍生版本时，应自行确保账号、隐私、日志和数据安全合规。

--- a/app.js
+++ b/app.js
@@ -55,10 +55,18 @@ if (!String.prototype.padStart) {
 }
 
 var i18n = require('./utils/i18n')
+var themeUtil = require('./utils/theme')
 
 App({
+  onLaunch: function () {
+    this.globalData.theme = themeUtil.getEffectiveTheme()
+    this.globalData.fontScaleStep = themeUtil.getFontScaleStep()
+    themeUtil.initThemeListener()
+  },
   globalData: {
     userInfo: null,
-    locale: i18n.getCurrentLocale()
+    locale: i18n.getCurrentLocale(),
+    theme: 'light',
+    fontScaleStep: 1
   }
 })

--- a/app.json
+++ b/app.json
@@ -25,8 +25,10 @@
     "pages/communityList/communityList",
     "pages/communityDetail/communityDetail",
     "pages/communityPublish/communityPublish",
-    "pages/communityCenter/communityCenter"
+    "pages/communityCenter/communityCenter",
+    "pages/appearance/appearance"
   ],
+  "darkmode": true,
   "window": {
     "backgroundTextStyle": "light",
     "navigationBarBackgroundColor": "#fff",

--- a/app.wxss
+++ b/app.wxss
@@ -1,5 +1,7 @@
+@import './styles/theme.wxss';
+
 page {
-  background-color: #F8F8F8;
+  background-color: var(--color-bg-primary);
   height: 100%;
   font-size: 32rpx;
   line-height: 1.6;

--- a/constants/features.js
+++ b/constants/features.js
@@ -212,6 +212,13 @@ const FEATURE_SECTIONS = [
 
 const SYSTEM_ACTIONS = [
   {
+    id: 'appearance',
+    title: '界面和外观',
+    description: '主题、字体大小、语言',
+    icon: '/image/mono/about.png',
+    page: '/pages/appearance/appearance'
+  },
+  {
     id: 'settings',
     title: '功能设置',
     description: '切换 mock 与管理首页模块',

--- a/locales/en.json
+++ b/locales/en.json
@@ -62,5 +62,25 @@
     "noAnnouncement": "No announcements",
     "noInteraction": "No messages",
     "markAllRead": "Mark all read"
+  },
+  "appearance": {
+    "title": "Interface & Appearance",
+    "theme": {
+      "label": "Theme",
+      "system": "Follow System",
+      "light": "Light Mode",
+      "dark": "Dark Mode"
+    },
+    "font": {
+      "label": "Font Size",
+      "small": "Small",
+      "standard": "Standard",
+      "large": "Large",
+      "xlarge": "Extra Large",
+      "preview": "Preview: GdeiAssistant Campus Helper"
+    },
+    "language": {
+      "label": "Language"
+    }
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -62,5 +62,25 @@
     "noAnnouncement": "お知らせはありません",
     "noInteraction": "メッセージはありません",
     "markAllRead": "すべて既読にする"
+  },
+  "appearance": {
+    "title": "インターフェースと外観",
+    "theme": {
+      "label": "テーマ",
+      "system": "システムに従う",
+      "light": "ライトモード",
+      "dark": "ダークモード"
+    },
+    "font": {
+      "label": "フォントサイズ",
+      "small": "小",
+      "standard": "標準",
+      "large": "大",
+      "xlarge": "特大",
+      "preview": "プレビュー：広東第二師範学院キャンパスアシスタント"
+    },
+    "language": {
+      "label": "言語"
+    }
   }
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -62,5 +62,25 @@
     "noAnnouncement": "공지사항이 없습니다",
     "noInteraction": "메시지가 없습니다",
     "markAllRead": "모두 읽음"
+  },
+  "appearance": {
+    "title": "인터페이스 및 외관",
+    "theme": {
+      "label": "테마",
+      "system": "시스템 설정 따르기",
+      "light": "라이트 모드",
+      "dark": "다크 모드"
+    },
+    "font": {
+      "label": "글꼴 크기",
+      "small": "작게",
+      "standard": "표준",
+      "large": "크게",
+      "xlarge": "매우 크게",
+      "preview": "미리보기: 광동제2사범학원 캠퍼스 도우미"
+    },
+    "language": {
+      "label": "언어"
+    }
   }
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -62,5 +62,25 @@
     "noAnnouncement": "暂无系统公告",
     "noInteraction": "暂无互动消息",
     "markAllRead": "全部已读"
+  },
+  "appearance": {
+    "title": "界面和外观",
+    "theme": {
+      "label": "主题",
+      "system": "跟随系统",
+      "light": "浅色模式",
+      "dark": "深色模式"
+    },
+    "font": {
+      "label": "字体大小",
+      "small": "小",
+      "standard": "标准",
+      "large": "大",
+      "xlarge": "超大",
+      "preview": "预览：广东第二师范学院校园助手"
+    },
+    "language": {
+      "label": "语言"
+    }
   }
 }

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -62,5 +62,25 @@
     "noAnnouncement": "暫無系統公告",
     "noInteraction": "暫無互動消息",
     "markAllRead": "全部已讀"
+  },
+  "appearance": {
+    "title": "介面和外觀",
+    "theme": {
+      "label": "主題",
+      "system": "跟隨系統",
+      "light": "淺色模式",
+      "dark": "深色模式"
+    },
+    "font": {
+      "label": "字體大小",
+      "small": "小",
+      "standard": "標準",
+      "large": "大",
+      "xlarge": "超大",
+      "preview": "預覽：廣東第二師範學院校園助手"
+    },
+    "language": {
+      "label": "語言"
+    }
   }
 }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -62,5 +62,25 @@
     "noAnnouncement": "暫無系統公告",
     "noInteraction": "暫無互動訊息",
     "markAllRead": "全部已讀"
+  },
+  "appearance": {
+    "title": "介面和外觀",
+    "theme": {
+      "label": "主題",
+      "system": "跟隨系統",
+      "light": "淺色模式",
+      "dark": "深色模式"
+    },
+    "font": {
+      "label": "字體大小",
+      "small": "小",
+      "standard": "標準",
+      "large": "大",
+      "xlarge": "超大",
+      "preview": "預覽：廣東第二師範學院校園助手"
+    },
+    "language": {
+      "label": "語言"
+    }
   }
 }

--- a/pages/appearance/appearance.js
+++ b/pages/appearance/appearance.js
@@ -1,0 +1,72 @@
+var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
+
+Page({
+  data: {
+    t: {},
+    themeClass: '',
+    themeMode: 'system',
+    fontScaleStep: 1,
+    fontScales: themeUtil.FONT_SCALES,
+    currentLocale: '',
+    locales: [
+      { code: 'zh-CN', label: '简体中文' },
+      { code: 'zh-HK', label: '繁體中文（香港）' },
+      { code: 'zh-TW', label: '繁體中文（台灣）' },
+      { code: 'en', label: 'English' },
+      { code: 'ja', label: '日本語' },
+      { code: 'ko', label: '한국어' }
+    ]
+  },
+
+  onLoad: function () {
+    this.refreshI18n()
+    themeUtil.applyTheme(this)
+    this.setData({
+      themeMode: themeUtil.getThemeMode(),
+      fontScaleStep: themeUtil.getFontScaleStep(),
+      currentLocale: i18n.getCurrentLocale()
+    })
+    wx.setNavigationBarTitle({ title: i18n.t('appearance.title') })
+  },
+
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        title: i18n.t('appearance.title'),
+        themeLabel: i18n.t('appearance.theme.label'),
+        themeSystem: i18n.t('appearance.theme.system'),
+        themeLight: i18n.t('appearance.theme.light'),
+        themeDark: i18n.t('appearance.theme.dark'),
+        fontLabel: i18n.t('appearance.font.label'),
+        fontSmall: i18n.t('appearance.font.small'),
+        fontStandard: i18n.t('appearance.font.standard'),
+        fontLarge: i18n.t('appearance.font.large'),
+        fontXlarge: i18n.t('appearance.font.xlarge'),
+        fontPreview: i18n.t('appearance.font.preview'),
+        langLabel: i18n.t('appearance.language.label')
+      }
+    })
+  },
+
+  onThemeSelect: function (e) {
+    var mode = e.currentTarget.dataset.mode
+    themeUtil.setThemeMode(mode)
+    themeUtil.applyTheme(this)
+    this.setData({ themeMode: mode })
+  },
+
+  onFontChange: function (e) {
+    var step = parseInt(e.detail.value, 10)
+    themeUtil.setFontScaleStep(step)
+    this.setData({ fontScaleStep: step })
+  },
+
+  onLocaleSelect: function (e) {
+    var code = e.currentTarget.dataset.code
+    i18n.setLocale(code)
+    this.setData({ currentLocale: code })
+    this.refreshI18n()
+    wx.setNavigationBarTitle({ title: i18n.t('appearance.title') })
+  }
+})

--- a/pages/appearance/appearance.json
+++ b/pages/appearance/appearance.json
@@ -1,0 +1,4 @@
+{
+  "usingComponents": {},
+  "navigationBarTitleText": ""
+}

--- a/pages/appearance/appearance.wxml
+++ b/pages/appearance/appearance.wxml
@@ -1,0 +1,37 @@
+<view class="page {{themeClass}}">
+  <view class="section-title">{{t.themeLabel}}</view>
+  <view class="option-list">
+    <view class="option-item" data-mode="system" bindtap="onThemeSelect">
+      <text>{{t.themeSystem}}</text>
+      <text class="check" wx:if="{{themeMode === 'system'}}">✓</text>
+    </view>
+    <view class="option-item" data-mode="light" bindtap="onThemeSelect">
+      <text>{{t.themeLight}}</text>
+      <text class="check" wx:if="{{themeMode === 'light'}}">✓</text>
+    </view>
+    <view class="option-item" data-mode="dark" bindtap="onThemeSelect">
+      <text>{{t.themeDark}}</text>
+      <text class="check" wx:if="{{themeMode === 'dark'}}">✓</text>
+    </view>
+  </view>
+
+  <view class="section-title">{{t.fontLabel}}</view>
+  <view class="font-card">
+    <slider min="0" max="3" step="1" value="{{fontScaleStep}}" activeColor="{{themeClass === 'theme-dark' ? '#34D399' : '#1AAD19'}}" bindchange="onFontChange" />
+    <view class="font-labels">
+      <text>{{t.fontSmall}}</text>
+      <text>{{t.fontStandard}}</text>
+      <text>{{t.fontLarge}}</text>
+      <text>{{t.fontXlarge}}</text>
+    </view>
+    <text class="font-preview" style="font-size: {{fontScales[fontScaleStep] * 28}}rpx">{{t.fontPreview}}</text>
+  </view>
+
+  <view class="section-title">{{t.langLabel}}</view>
+  <view class="option-list">
+    <view class="option-item" wx:for="{{locales}}" wx:key="code" data-code="{{item.code}}" bindtap="onLocaleSelect">
+      <text>{{item.label}}</text>
+      <text class="check" wx:if="{{currentLocale === item.code}}">✓</text>
+    </view>
+  </view>
+</view>

--- a/pages/appearance/appearance.wxss
+++ b/pages/appearance/appearance.wxss
@@ -1,0 +1,39 @@
+.page {
+  min-height: 100vh;
+  background: var(--color-bg-primary);
+}
+.section-title {
+  font-size: 26rpx;
+  color: var(--color-text-secondary);
+  padding: 24rpx 32rpx 12rpx;
+}
+.option-list {
+  background: var(--color-surface);
+}
+.option-item {
+  padding: 24rpx 32rpx;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1rpx solid var(--color-divider);
+  color: var(--color-text-primary);
+}
+.check {
+  color: var(--color-primary);
+}
+.font-card {
+  background: var(--color-surface);
+  padding: 24rpx 32rpx;
+}
+.font-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 22rpx;
+  color: var(--color-text-secondary);
+  margin-top: 8rpx;
+}
+.font-preview {
+  display: block;
+  margin-top: 20rpx;
+  color: var(--color-text-primary);
+}

--- a/pages/bill/bill.js
+++ b/pages/bill/bill.js
@@ -1,9 +1,14 @@
 const utils = require('../../utils/util.js')
 const campusApi = require('../../services/apis/campus.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     date: null,
     start: null,
     end: null,

--- a/pages/bill/bill.wxml
+++ b/pages/bill/bill.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd">
+<view class="page__bd {{themeClass}}">
 
   <view class="container">
 

--- a/pages/bill/bill.wxss
+++ b/pages/bill/bill.wxss
@@ -2,5 +2,5 @@
 
 .weui-navbar {
   position: static;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }

--- a/pages/book/book.js
+++ b/pages/book/book.js
@@ -1,9 +1,14 @@
 const utils = require('../../utils/util.js')
 const libraryApi = require('../../services/apis/library.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     password: '',
     result: [],
     hasQueriedBorrow: false,

--- a/pages/book/book.wxml
+++ b/pages/book/book.wxml
@@ -1,4 +1,4 @@
-<view block class="page__bd">
+<view block class="page__bd {{themeClass}}">
 
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 

--- a/pages/book/book.wxss
+++ b/pages/book/book.wxss
@@ -2,7 +2,7 @@
 
 .weui-navbar {
   position: static;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 .borrow-empty {
@@ -30,7 +30,7 @@
   max-width: 640rpx;
   padding: 36rpx 32rpx;
   border-radius: 28rpx;
-  background: #ffffff;
+  background: var(--color-surface);
   box-sizing: border-box;
 }
 

--- a/pages/card/card.js
+++ b/pages/card/card.js
@@ -1,8 +1,13 @@
 const utils = require('../../utils/util.js')
 const campusApi = require('../../services/apis/campus.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     card: null
   },
 

--- a/pages/card/card.wxml
+++ b/pages/card/card.wxml
@@ -1,4 +1,4 @@
-<view block class="page__bd">
+<view block class="page__bd {{themeClass}}">
   <view class="container" wx:if="{{card}}">
     <view class="module_shortcuts">
       <navigator url="/pages/bill/bill" class="shortcut_card" hover-class="shortcut_card_active">

--- a/pages/card/card.wxss
+++ b/pages/card/card.wxss
@@ -2,7 +2,7 @@
 
 .weui-navbar {
   position: static;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 .module_shortcuts {

--- a/pages/cardLost/cardLost.js
+++ b/pages/cardLost/cardLost.js
@@ -1,8 +1,13 @@
 const campusApi = require('../../services/apis/campus.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     loading: false,
     errorMessage: null
   },

--- a/pages/cardLost/cardLost.wxml
+++ b/pages/cardLost/cardLost.wxml
@@ -1,4 +1,4 @@
-<view block class="page__bd">
+<view block class="page__bd {{themeClass}}">
 
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 

--- a/pages/cardLost/cardLost.wxss
+++ b/pages/cardLost/cardLost.wxss
@@ -2,10 +2,10 @@
 
 .weui-navbar {
   position: static;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 .lost_warning {
   text-align: center;
-  color: #aaa;
+  color: var(--color-text-tertiary);
 }

--- a/pages/cet/cet.js
+++ b/pages/cet/cet.js
@@ -1,9 +1,14 @@
 const cetApi = require('../../services/apis/cet.js')
 const dataSource = require('../../services/data-source.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     ticketNumber: '',
     name: '',
     checkcode: '',

--- a/pages/cet/cet.wxml
+++ b/pages/cet/cet.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd">
+<view class="page__bd {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="container" wx:if="{{!result}}">

--- a/pages/cet/cet.wxss
+++ b/pages/cet/cet.wxss
@@ -9,7 +9,7 @@
   min-width: 160rpx;
   padding: 10rpx 20rpx;
   border-radius: 8rpx;
-  background-color: #f5f5f5;
+  background-color: var(--color-bg-secondary);
   text-align: center;
-  color: #576b95;
+  color: var(--color-link);
 }

--- a/pages/collection/collection.js
+++ b/pages/collection/collection.js
@@ -1,8 +1,13 @@
 const libraryApi = require('../../services/apis/library.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     list: [],
     keyword: null,
     currentPage: 0,

--- a/pages/collection/collection.wxml
+++ b/pages/collection/collection.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd">
+<view class="page__bd {{themeClass}}">
 
   <view class="container">
 

--- a/pages/collection/collection.wxss
+++ b/pages/collection/collection.wxss
@@ -2,14 +2,14 @@
 
 .weui-navbar {
   position: static;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 .loadmore {
   margin-top: 20rpx;
   margin-bottom: 20rpx;
   text-align: center;
-  color: #aaa;
+  color: var(--color-text-tertiary);
 }
 
 .module_shortcuts {

--- a/pages/collectionDetail/collectionDetail.js
+++ b/pages/collectionDetail/collectionDetail.js
@@ -1,8 +1,13 @@
 const libraryApi = require('../../services/apis/library.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     query: null,
     result: null,
     errorMessage: null

--- a/pages/collectionDetail/collectionDetail.wxml
+++ b/pages/collectionDetail/collectionDetail.wxml
@@ -1,4 +1,4 @@
-<view block class="page__bd">
+<view block class="page__bd {{themeClass}}">
 
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 

--- a/pages/collectionDetail/collectionDetail.wxss
+++ b/pages/collectionDetail/collectionDetail.wxss
@@ -2,5 +2,5 @@
 
 .weui-navbar {
   position: static;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }

--- a/pages/communityCenter/communityCenter.js
+++ b/pages/communityCenter/communityCenter.js
@@ -2,6 +2,7 @@ const { getCommunityModule, getCommunityPageTitle } = require('../../constants/c
 const communityApi = require('../../services/apis/community.js')
 const userApi = require('../../services/apis/user.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 function buildTabs(moduleId) {
   switch (moduleId) {
@@ -57,6 +58,7 @@ function formatSecretPublishText(publishTime, timer) {
 
 Page({
   data: {
+    themeClass: '',
     moduleId: '',
     moduleConfig: null,
     tabs: [],
@@ -469,6 +471,7 @@ Page({
   },
 
   onShow: function() {
+    themeUtil.applyTheme(this)
     if (!this.data.hasShownOnce) {
       this.setData({
         hasShownOnce: true

--- a/pages/communityCenter/communityCenter.wxml
+++ b/pages/communityCenter/communityCenter.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd center_page">
+<view class="page__bd center_page {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="hero_card" wx:if="{{moduleConfig}}" style="{{moduleConfig.heroStyle}}">

--- a/pages/communityCenter/communityCenter.wxss
+++ b/pages/communityCenter/communityCenter.wxss
@@ -2,7 +2,7 @@
 
 .center_page {
   min-height: 100vh;
-  background: #F8F8F8;
+  background: var(--color-bg-primary);
   padding-bottom: 120rpx;
 }
 
@@ -23,7 +23,7 @@
 }
 
 .hero_title {
-  color: #222;
+  color: var(--color-text-primary);
   font-size: 38rpx;
   font-weight: 700;
 }
@@ -47,7 +47,7 @@
   display: flex;
   align-items: center;
   gap: 20rpx;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 24rpx;
   box-shadow: 0 14rpx 34rpx rgba(0, 0, 0, 0.045);
 }
@@ -65,14 +65,14 @@
 }
 
 .summary_name {
-  color: #222;
+  color: var(--color-text-primary);
   font-size: 30rpx;
   font-weight: 600;
 }
 
 .summary_intro {
   margin-top: 12rpx;
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 24rpx;
   line-height: 1.7;
 }
@@ -90,15 +90,15 @@
   margin-right: 16rpx;
   padding: 18rpx 28rpx;
   border-radius: 999rpx;
-  background: #fff;
-  color: #666;
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
   font-size: 26rpx;
   box-shadow: 0 8rpx 20rpx rgba(0, 0, 0, 0.03);
 }
 
 .tab_item_active {
   background: #2f2f2f;
-  color: #fff;
+  color: var(--color-surface);
 }
 
 .loading_box,
@@ -106,9 +106,9 @@
   margin: 24rpx;
   padding: 80rpx 30rpx;
   text-align: center;
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 26rpx;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 24rpx;
   box-shadow: 0 12rpx 30rpx rgba(0, 0, 0, 0.04);
 }
@@ -119,7 +119,7 @@
 
 .center_card {
   margin-bottom: 20rpx;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 24rpx;
   overflow: hidden;
   box-shadow: 0 14rpx 34rpx rgba(0, 0, 0, 0.045);
@@ -153,21 +153,21 @@
 .card_title {
   font-size: 30rpx;
   font-weight: 600;
-  color: #222;
+  color: var(--color-text-primary);
   line-height: 1.5;
 }
 
 .card_summary,
 .contact_hint {
   margin-top: 12rpx;
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 26rpx;
   line-height: 1.7;
 }
 
 .card_time {
   margin-top: 12rpx;
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 22rpx;
 }
 
@@ -193,14 +193,14 @@
 }
 
 .empty_title {
-  color: #333;
+  color: var(--color-text-primary);
   font-size: 30rpx;
   font-weight: 600;
 }
 
 .empty_summary {
   margin-top: 12rpx;
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 24rpx;
   line-height: 1.7;
 }

--- a/pages/communityDetail/communityDetail.js
+++ b/pages/communityDetail/communityDetail.js
@@ -9,6 +9,7 @@ const { fetchProfileOptions } = require('../../constants/profile.js')
 const communityApi = require('../../services/apis/community.js')
 const pageUtils = require('../../utils/page.js')
 const { createSubmitGuard } = require('../../utils/debounce.js')
+var themeUtil = require('../../utils/theme')
 
 const commentGuard = createSubmitGuard()
 const guessGuard = createSubmitGuard()
@@ -228,7 +229,11 @@ function buildDetail(moduleId, payload) {
 }
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     moduleId: '',
     moduleConfig: null,
     detailId: '',

--- a/pages/communityDetail/communityDetail.wxml
+++ b/pages/communityDetail/communityDetail.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd detail_page">
+<view class="page__bd detail_page {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="loading_box" wx:if="{{loading}}">

--- a/pages/communityDetail/communityDetail.wxss
+++ b/pages/communityDetail/communityDetail.wxss
@@ -2,7 +2,7 @@
 
 .detail_page {
   min-height: 100vh;
-  background: #F8F8F8;
+  background: var(--color-bg-primary);
   padding-bottom: 40rpx;
 }
 
@@ -12,7 +12,7 @@
   flex-direction: column;
   gap: 20rpx;
   align-items: center;
-  color: #888;
+  color: var(--color-text-secondary);
 }
 
 .detail_swiper {
@@ -28,7 +28,7 @@
 .detail_card {
   margin: 20rpx 24rpx 0;
   padding: 26rpx;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 24rpx;
   box-shadow: 0 14rpx 34rpx rgba(0, 0, 0, 0.045);
 }
@@ -53,14 +53,14 @@
 }
 
 .detail_head_time {
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 22rpx;
 }
 
 .detail_title {
   font-size: 34rpx;
   font-weight: 600;
-  color: #222;
+  color: var(--color-text-primary);
   line-height: 1.5;
 }
 
@@ -71,7 +71,7 @@
 .comment_time,
 .detail_hint {
   margin-top: 12rpx;
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 24rpx;
   line-height: 1.7;
 }
@@ -99,7 +99,7 @@
 
 .detail_badge_secondary {
   background: #f1f4f6;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .detail_desc,
@@ -115,7 +115,7 @@
 .section_title {
   font-size: 28rpx;
   font-weight: 600;
-  color: #222;
+  color: var(--color-text-primary);
 }
 
 .contact_row,
@@ -152,7 +152,7 @@
 
 .comment_item {
   padding: 18rpx 0;
-  border-bottom: 1rpx solid #f2f2f2;
+  border-bottom: 1rpx solid var(--color-bg-secondary);
 }
 
 .comment_item:last-child {

--- a/pages/communityList/communityList.js
+++ b/pages/communityList/communityList.js
@@ -11,6 +11,7 @@ const {
 const { fetchProfileOptions } = require('../../constants/profile.js')
 const communityApi = require('../../services/apis/community.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 function findLabel(options, value, fallback) {
   const item = (options || []).filter(function(optionItem) {
@@ -135,6 +136,7 @@ function normalizeItem(moduleId, item) {
 
 Page({
   data: {
+    themeClass: '',
     moduleId: '',
     moduleConfig: null,
     searchKeyword: '',
@@ -359,6 +361,7 @@ Page({
   },
 
   onShow: function() {
+    themeUtil.applyTheme(this)
     if (this.data.moduleId) {
       this.loadStatsIfNeeded()
     }

--- a/pages/communityList/communityList.wxml
+++ b/pages/communityList/communityList.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd community-page">
+<view class="page__bd community-page {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="hero_card" wx:if="{{moduleConfig}}" style="{{moduleConfig.heroStyle}}">

--- a/pages/communityList/communityList.wxss
+++ b/pages/communityList/communityList.wxss
@@ -2,7 +2,7 @@
 
 .community-page {
   padding-bottom: 130rpx;
-  background: #F8F8F8;
+  background: var(--color-bg-primary);
   min-height: 100vh;
 }
 
@@ -23,7 +23,7 @@
 }
 
 .hero_title {
-  color: #222;
+  color: var(--color-text-primary);
   font-size: 38rpx;
   font-weight: 700;
 }
@@ -47,7 +47,7 @@
   padding: 24rpx;
   display: flex;
   justify-content: space-between;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 20rpx;
   box-shadow: 0 10rpx 24rpx rgba(0, 0, 0, 0.04);
 }
@@ -62,12 +62,12 @@
 .stat_value {
   font-size: 36rpx;
   font-weight: 600;
-  color: #222;
+  color: var(--color-text-primary);
 }
 
 .stat_label {
   font-size: 28rpx;
-  color: #888;
+  color: var(--color-text-secondary);
 }
 
 .search_bar {
@@ -76,7 +76,7 @@
   gap: 12rpx;
   align-items: center;
   padding: 14rpx;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 24rpx;
   box-shadow: 0 10rpx 24rpx rgba(0, 0, 0, 0.04);
 }
@@ -97,7 +97,7 @@
 
 .search_button_secondary {
   background: #f1f1f1;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .tab_scroll {
@@ -114,15 +114,15 @@
   margin-right: 16rpx;
   padding: 16rpx 28rpx;
   border-radius: 999rpx;
-  background: #fff;
-  color: #666;
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
   font-size: 28rpx;
   box-shadow: 0 8rpx 20rpx rgba(0, 0, 0, 0.03);
 }
 
 .tab_item_active {
   background: #2f2f2f;
-  color: #fff;
+  color: var(--color-surface);
 }
 
 .list_section {
@@ -134,7 +134,7 @@
 .delivery_card,
 .photo_card {
   margin-bottom: 20rpx;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 24rpx;
   overflow: hidden;
   box-shadow: 0 14rpx 34rpx rgba(0, 0, 0, 0.045);
@@ -167,7 +167,7 @@
 .dating_card {
   width: 48.2%;
   margin-bottom: 20rpx;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 22rpx;
   overflow: hidden;
   box-shadow: 0 14rpx 34rpx rgba(0, 0, 0, 0.045);
@@ -211,13 +211,13 @@
 .card_title {
   font-size: 30rpx;
   font-weight: 600;
-  color: #222;
+  color: var(--color-text-primary);
   line-height: 1.5;
 }
 
 .card_summary {
   margin-top: 14rpx;
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 28rpx;
   line-height: 1.7;
   word-break: break-word;
@@ -237,7 +237,7 @@
 
 .card_sub_badge {
   background: #f4f6f8;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .delivery_badge {
@@ -247,7 +247,7 @@
 
 .card_meta {
   flex: 1;
-  color: #888;
+  color: var(--color-text-secondary);
   font-size: 28rpx;
   line-height: 1.5;
 }
@@ -260,7 +260,7 @@
 
 .time_text,
 .metric_text {
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 22rpx;
 }
 
@@ -338,28 +338,28 @@
 }
 
 .bottom_button_secondary {
-  background: #fff;
+  background: var(--color-surface);
   color: #2f2f2f;
 }
 
 .empty_panel {
   margin: 24rpx;
   padding: 52rpx 32rpx;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 24rpx;
   text-align: center;
   box-shadow: 0 12rpx 30rpx rgba(0, 0, 0, 0.04);
 }
 
 .empty_title {
-  color: #333;
+  color: var(--color-text-primary);
   font-size: 30rpx;
   font-weight: 600;
 }
 
 .empty_summary {
   margin-top: 14rpx;
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 24rpx;
   line-height: 1.7;
 }

--- a/pages/communityPublish/communityPublish.js
+++ b/pages/communityPublish/communityPublish.js
@@ -17,6 +17,7 @@ const { fetchProfileOptions } = require('../../constants/profile.js')
 const communityApi = require('../../services/apis/community.js')
 const { uploadLocalFileByPresignedUrl, uploadLocalFilesByPresignedUrl } = require('../../services/upload.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 const EDITABLE_MODULE_IDS = ['ershou', 'lostandfound']
 
@@ -125,7 +126,11 @@ function findEditableItem(moduleId, payload, itemId) {
 }
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     moduleId: '',
     moduleConfig: null,
     mode: 'create',

--- a/pages/communityPublish/communityPublish.wxml
+++ b/pages/communityPublish/communityPublish.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd publish_page">
+<view class="page__bd publish_page {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="hero_card" wx:if="{{moduleConfig}}" style="{{moduleConfig.heroStyle}}">

--- a/pages/communityPublish/communityPublish.wxss
+++ b/pages/communityPublish/communityPublish.wxss
@@ -2,7 +2,7 @@
 
 .publish_page {
   min-height: 100vh;
-  background: #F8F8F8;
+  background: var(--color-bg-primary);
   padding: 20rpx 24rpx 40rpx;
   box-sizing: border-box;
 }
@@ -24,7 +24,7 @@
 }
 
 .hero_title {
-  color: #222;
+  color: var(--color-text-primary);
   font-size: 38rpx;
   font-weight: 700;
 }
@@ -45,26 +45,26 @@
 .publish_card {
   margin-bottom: 20rpx;
   padding: 26rpx;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 24rpx;
   box-shadow: 0 14rpx 34rpx rgba(0, 0, 0, 0.045);
 }
 
 .section_title {
   margin-bottom: 18rpx;
-  color: #222;
+  color: var(--color-text-primary);
   font-size: 28rpx;
   font-weight: 600;
 }
 
 .page_hint {
   margin-bottom: 18rpx;
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 24rpx;
 }
 
 .picker_value {
-  color: #333;
+  color: var(--color-text-primary);
   font-size: 28rpx;
 }
 
@@ -77,7 +77,7 @@
 
 .voice_hint,
 .upload_hint {
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 24rpx;
 }
 
@@ -110,7 +110,7 @@
   height: 40rpx;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.5);
-  color: #fff;
+  color: var(--color-surface);
   text-align: center;
   line-height: 40rpx;
   font-size: 24rpx;

--- a/pages/data/data.js
+++ b/pages/data/data.js
@@ -1,4 +1,8 @@
+var themeUtil = require('../../utils/theme')
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   onShareAppMessage: function() {
     return {
       title: '数据查询',

--- a/pages/data/data.wxml
+++ b/pages/data/data.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd">
+<view class="page__bd {{themeClass}}">
   <view class="weui-cells__title">选择查询项目</view>
   <view class="weui-cells weui-cells_after-title">
     <navigator url="/pages/electricity/electricity" class="weui-cell weui-cell_access" hover-class="weui-cell_active">

--- a/pages/electricity/electricity.js
+++ b/pages/electricity/electricity.js
@@ -1,5 +1,6 @@
 const dataApi = require('../../services/apis/data.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 function buildYearOptions() {
   const currentYear = new Date().getFullYear()
@@ -11,7 +12,11 @@ function buildYearOptions() {
 }
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     yearOptions: buildYearOptions(),
     yearIndex: 0,
     name: '',

--- a/pages/electricity/electricity.wxml
+++ b/pages/electricity/electricity.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd">
+<view class="page__bd {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="container" wx:if="{{!result}}">

--- a/pages/evaluate/evaluate.js
+++ b/pages/evaluate/evaluate.js
@@ -1,9 +1,14 @@
 const utils = require('../../utils/util.js')
 const campusApi = require('../../services/apis/campus.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     checked: false,
     loading: false,
     errorMessage: null

--- a/pages/evaluate/evaluate.wxml
+++ b/pages/evaluate/evaluate.wxml
@@ -1,4 +1,4 @@
-<view block class="page__bd">
+<view block class="page__bd {{themeClass}}">
 
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 

--- a/pages/evaluate/evaluate.wxss
+++ b/pages/evaluate/evaluate.wxss
@@ -2,5 +2,5 @@
 
 .weui-navbar {
   position: static;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }

--- a/pages/grade/grade.js
+++ b/pages/grade/grade.js
@@ -1,8 +1,13 @@
 const utils = require('../../utils/util.js')
 const campusApi = require('../../services/apis/campus.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     tabs: ['大一', '大二', '大三', '大四'],
     firstTermGradeList: null,
     secondTermGradeList: null,

--- a/pages/grade/grade.wxml
+++ b/pages/grade/grade.wxml
@@ -1,3 +1,4 @@
+<view class="page-root {{themeClass}}">
 <view class="weui-navbar">
   <block wx:for="{{tabs}}" wx:key="*this">
     <view id="{{index}}" class="weui-navbar__item {{activeIndex == index ? 'weui-bar__item_on' : ''}}" bindtap="tabClick">
@@ -24,4 +25,4 @@
       </view>
     </view>
   </view>
-</view>
+</view></view>

--- a/pages/grade/grade.wxss
+++ b/pages/grade/grade.wxss
@@ -2,5 +2,5 @@
 
 .weui-navbar {
   position: static;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }

--- a/pages/graduateExam/graduateExam.js
+++ b/pages/graduateExam/graduateExam.js
@@ -1,8 +1,13 @@
 const infoApi = require('../../services/apis/info.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     name: '',
     examNumber: '',
     idNumber: '',

--- a/pages/graduateExam/graduateExam.wxml
+++ b/pages/graduateExam/graduateExam.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd">
+<view class="page__bd {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="container" wx:if="{{!result}}">

--- a/pages/inbox/inbox.js
+++ b/pages/inbox/inbox.js
@@ -1,6 +1,7 @@
 const storageKeys = require('../../constants/storage.js')
 const messagesApi = require('../../services/apis/messages.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 const PAGE_SIZE = 10
 const INBOX_TABS = [
@@ -132,6 +133,7 @@ function buildInteractionUrl(item) {
 
 Page({
   data: {
+    themeClass: '',
     inboxTabs: INBOX_TABS,
     activeTab: 'announcement',
     announcementList: [],
@@ -325,6 +327,7 @@ Page({
   },
 
   onShow: function() {
+    themeUtil.applyTheme(this)
     if (this.data.activeTab === 'interaction') {
       this.loadInteractionMeta()
     }

--- a/pages/inbox/inbox.wxml
+++ b/pages/inbox/inbox.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd inbox_page">
+<view class="page__bd inbox_page {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="weui-navbar inbox_tabs">

--- a/pages/inbox/inbox.wxss
+++ b/pages/inbox/inbox.wxss
@@ -2,19 +2,19 @@
 
 .inbox_page {
   padding-bottom: 28rpx;
-  background: #F8F8F8;
+  background: var(--color-bg-primary);
 }
 
 .inbox_tabs {
   position: sticky;
   top: 0;
   z-index: 20;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 .section_card {
   margin: 24rpx 24rpx 0;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 24rpx;
   overflow: hidden;
   box-shadow: 0 12rpx 32rpx rgba(0, 0, 0, 0.04);
@@ -22,13 +22,13 @@
 
 .item_title {
   padding-right: 20rpx;
-  color: #333;
+  color: var(--color-text-primary);
   word-break: break-word;
 }
 
 .item_summary {
   margin-top: 8rpx;
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 24rpx;
   line-height: 1.6;
 }
@@ -45,7 +45,7 @@
 }
 
 .meta_badge {
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 24rpx;
 }
 
@@ -62,7 +62,7 @@
   margin-top: 16rpx;
   padding: 24rpx;
   border-radius: 18rpx;
-  background: #f8f8f8;
+  background: var(--color-bg-primary);
 }
 
 .interaction_card:first-child {
@@ -83,7 +83,7 @@
 .interaction_title {
   flex: 1;
   min-width: 0;
-  color: #333;
+  color: var(--color-text-primary);
   font-size: 30rpx;
   font-weight: 600;
 }
@@ -96,12 +96,12 @@
 }
 
 .interaction_read_done {
-  background: #ececec;
+  background: var(--color-divider);
   color: #9a9a9a;
 }
 
 .interaction_read_pending {
-  background: #dfdfdf;
+  background: var(--color-border);
   color: #555;
 }
 
@@ -115,18 +115,18 @@
 .interaction_tag {
   padding: 4rpx 12rpx;
   border-radius: 999rpx;
-  background: #ebebeb;
+  background: var(--color-bg-tertiary);
   color: #777;
   font-size: 22rpx;
 }
 
 .interaction_tag_secondary {
-  background: #f0f0f0;
+  background: var(--color-bg-secondary);
 }
 
 .interaction_content {
   margin-top: 18rpx;
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 26rpx;
   line-height: 1.7;
 }

--- a/pages/index/index.js
+++ b/pages/index/index.js
@@ -4,6 +4,7 @@ const messagesApi = require('../../services/apis/messages.js')
 const userApi = require('../../services/apis/user.js')
 const featureConfig = require('../../services/feature-config.js')
 const dataSource = require('../../services/data-source.js')
+var themeUtil = require('../../utils/theme')
 
 function formatInboxBadge(unreadCount) {
   const count = Number(unreadCount || 0)
@@ -15,6 +16,7 @@ function formatInboxBadge(unreadCount) {
 
 Page({
   data: {
+    themeClass: '',
     avatar: null,
     nickname: null,
     homeSections: [],
@@ -134,6 +136,7 @@ Page({
   },
 
   onShow: function() {
+    themeUtil.applyTheme(this)
     this.loadProfile()
     this.loadInboxStatus()
     this.loadHomeSections()

--- a/pages/index/index.wxml
+++ b/pages/index/index.wxml
@@ -1,4 +1,4 @@
-<view class="container">
+<view class="container {{themeClass}}">
 
 <official-account></official-account>
 

--- a/pages/index/index.wxss
+++ b/pages/index/index.wxss
@@ -4,7 +4,7 @@
   margin-top: 35rpx;
   margin-bottom: 35rpx;
   text-align: center;
-  color: #aaa;
+  color: var(--color-text-tertiary);
 }
 
 .userinfo_card {
@@ -13,7 +13,7 @@
   justify-content: space-between;
   margin: 20rpx 24rpx 0;
   padding: 28rpx 30rpx;
-  background: linear-gradient(180deg, #ffffff 0%, #fbfbfb 100%);
+  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-bg-secondary) 100%);
   border-radius: 26rpx;
   box-shadow: 0 14rpx 34rpx rgba(0, 0, 0, 0.05);
 }
@@ -43,14 +43,14 @@
 }
 
 .userinfo-nickname {
-  color: #333;
+  color: var(--color-text-primary);
   font-size: 34rpx;
   font-weight: 600;
 }
 
 .userinfo-source {
   margin-top: 8rpx;
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 24rpx;
 }
 
@@ -70,7 +70,7 @@
   height: 84rpx;
   margin-left: 24rpx;
   border-radius: 24rpx;
-  background: #f2f2f2;
+  background: var(--color-bg-secondary);
   flex-shrink: 0;
 }
 
@@ -86,8 +86,8 @@
   min-width: 36rpx;
   padding: 4rpx 10rpx;
   border-radius: 999rpx;
-  background: #e94747;
-  color: #fff;
+  background: var(--color-danger);
+  color: var(--color-surface);
   font-size: 22rpx;
   text-align: center;
   line-height: 1.2;
@@ -97,7 +97,7 @@
 .section_title {
   padding: 0 30rpx;
   margin-bottom: 10rpx;
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 28rpx;
 }
 

--- a/pages/login/login.js
+++ b/pages/login/login.js
@@ -5,11 +5,13 @@ const auth = require('../../services/auth.js')
 const authApi = require('../../services/apis/auth.js')
 const dataSource = require('../../services/data-source.js')
 const { createSubmitGuard } = require('../../utils/debounce.js')
+var themeUtil = require('../../utils/theme')
 
 const loginGuard = createSubmitGuard()
 
 Page({
   data: {
+    themeClass: '',
     ready: false,
     versionCode: '',
     useMockData: false,
@@ -104,6 +106,7 @@ Page({
   },
 
   onShow: function() {
+    themeUtil.applyTheme(this)
     this.refreshRuntimeState()
   }
 })

--- a/pages/login/login.wxml
+++ b/pages/login/login.wxml
@@ -1,4 +1,4 @@
-<view class="container" wx:if="{{ready}}">
+<view class="container {{themeClass}}" wx:if="{{ready}}">
 
   <view class="userinfo">
     <image class="userinfo-avatar" src="../../image/logo.png" background-size="cover"></image>

--- a/pages/login/login.wxss
+++ b/pages/login/login.wxss
@@ -27,18 +27,18 @@ form {
 }
 
 .userinfo-nickname {
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .userinfo-source {
-  color: #bbb;
+  color: var(--color-text-tertiary);
   font-size: 26rpx;
 }
 
 .mock_hint {
   display: block;
   margin: 20rpx 40rpx 0;
-  color: #888;
+  color: var(--color-text-secondary);
   text-align: center;
   font-size: 26rpx;
 }
@@ -46,7 +46,7 @@ form {
 .settings_link {
   display: block;
   margin-top: 20rpx;
-  color: #576b95;
+  color: var(--color-link);
   text-align: center;
   font-size: 28rpx;
 }
@@ -55,5 +55,5 @@ form {
   margin-top: 35rpx;
   margin-bottom: 35rpx;
   text-align: center;
-  color: #aaa;
+  color: var(--color-text-tertiary);
 }

--- a/pages/news/news.js
+++ b/pages/news/news.js
@@ -1,6 +1,7 @@
 const storageKeys = require('../../constants/storage.js')
 const infoApi = require('../../services/apis/info.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 const PAGE_SIZE = 10
 const NEWS_TABS = [
@@ -11,7 +12,11 @@ const NEWS_TABS = [
 ]
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     tabs: NEWS_TABS,
     activeType: 1,
     newsList: [],

--- a/pages/news/news.wxml
+++ b/pages/news/news.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd news_page">
+<view class="page__bd news_page {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <scroll-view scroll-x class="news_type_scroll" enable-flex>

--- a/pages/news/news.wxss
+++ b/pages/news/news.wxss
@@ -2,7 +2,7 @@
 
 .news_page {
   padding-bottom: 28rpx;
-  background: #F8F8F8;
+  background: var(--color-bg-primary);
 }
 
 .news_type_scroll {
@@ -11,7 +11,7 @@
   z-index: 20;
   white-space: nowrap;
   padding: 20rpx 24rpx 18rpx;
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .news_type_row {
@@ -23,18 +23,18 @@
   padding: 10rpx 22rpx;
   border-radius: 999rpx;
   background: #f1f1f1;
-  color: #888;
+  color: var(--color-text-secondary);
   font-size: 24rpx;
 }
 
 .news_type_item_active {
-  background: #e3e3e3;
+  background: var(--color-divider);
   color: #4f4f4f;
 }
 
 .section_card {
   margin: 24rpx;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 24rpx;
   overflow: hidden;
   box-shadow: 0 12rpx 32rpx rgba(0, 0, 0, 0.04);
@@ -46,7 +46,7 @@
 
 .news_title {
   padding-right: 20rpx;
-  color: #333;
+  color: var(--color-text-primary);
   word-break: break-word;
 }
 

--- a/pages/newsDetail/newsDetail.js
+++ b/pages/newsDetail/newsDetail.js
@@ -2,9 +2,14 @@ const storageKeys = require('../../constants/storage.js')
 const infoApi = require('../../services/apis/info.js')
 const messagesApi = require('../../services/apis/messages.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     newsItem: null,
     loading: false,
     errorMessage: null,

--- a/pages/newsDetail/newsDetail.wxml
+++ b/pages/newsDetail/newsDetail.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd">
+<view class="page__bd {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
   <view class="container detail-loading" wx:if="{{loading && !newsItem}}">
     <i class="weui-loading"></i>

--- a/pages/newsDetail/newsDetail.wxss
+++ b/pages/newsDetail/newsDetail.wxss
@@ -3,19 +3,19 @@
 .detail-loading {
   padding: 80rpx 30rpx;
   text-align: center;
-  color: #888;
+  color: var(--color-text-secondary);
 }
 
 .detail_title {
   padding: 40rpx 30rpx 20rpx;
   font-size: 36rpx;
-  color: #333;
+  color: var(--color-text-primary);
   font-weight: 600;
 }
 
 .detail_date {
   padding: 0 30rpx 20rpx;
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 26rpx;
 }
 

--- a/pages/profile/profile.js
+++ b/pages/profile/profile.js
@@ -2,6 +2,7 @@ const userApi = require('../../services/apis/user.js')
 const uploadService = require('../../services/upload.js')
 const pageUtils = require('../../utils/page.js')
 const LOCATION_REGIONS = require('../../constants/location-regions.js')
+var themeUtil = require('../../utils/theme')
 const {
   fetchProfileOptions,
   getFacultyCodeByLabel,
@@ -469,7 +470,11 @@ function validateIntroduction(introduction) {
 }
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     loading: true,
     errorMessage: null,
     todayDate: '',

--- a/pages/profile/profile.wxml
+++ b/pages/profile/profile.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd profile_page">
+<view class="page__bd profile_page {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="loading_box" wx:if="{{loading}}">

--- a/pages/profile/profile.wxss
+++ b/pages/profile/profile.wxss
@@ -3,13 +3,13 @@
 .profile_page {
   min-height: 100vh;
   padding-bottom: 40rpx;
-  background: #F8F8F8;
+  background: var(--color-bg-primary);
 }
 
 .loading_box {
   padding: 80rpx 0;
   text-align: center;
-  color: #999;
+  color: var(--color-text-tertiary);
 }
 
 .loading_box text {
@@ -22,7 +22,7 @@
   align-items: flex-start;
   margin: 24rpx 24rpx 0;
   padding: 30rpx;
-  background: linear-gradient(180deg, #ffffff 0%, #fbfbfb 100%);
+  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-bg-secondary) 100%);
   border-radius: 28rpx;
   box-shadow: 0 16rpx 40rpx rgba(0, 0, 0, 0.05);
 }
@@ -36,8 +36,8 @@
   width: 132rpx;
   height: 132rpx;
   border-radius: 50%;
-  background: #f2f2f2;
-  border: 6rpx solid #fff;
+  background: var(--color-bg-secondary);
+  border: 6rpx solid var(--color-surface);
   box-shadow: 0 10rpx 26rpx rgba(0, 0, 0, 0.08);
 }
 
@@ -50,7 +50,7 @@
   padding: 8rpx 14rpx;
   border-radius: 999rpx;
   background: rgba(51, 51, 51, 0.86);
-  color: #fff;
+  color: var(--color-surface);
   font-size: 20rpx;
   text-align: center;
   white-space: nowrap;
@@ -66,7 +66,7 @@
 .profile_name {
   font-size: 36rpx;
   font-weight: 700;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .profile_subtitle {
@@ -83,7 +83,7 @@
 
 .profile_intro {
   margin-top: 18rpx;
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 26rpx;
   line-height: 1.7;
 }
@@ -103,7 +103,7 @@
 .profile_textarea {
   width: 100%;
   box-sizing: border-box;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .profile_textarea {

--- a/pages/schedule/schedule.js
+++ b/pages/schedule/schedule.js
@@ -1,8 +1,13 @@
 const utils = require('../../utils/util.js')
 const campusApi = require('../../services/apis/campus.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     index: 0,
     array: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
     scheduleList: null,

--- a/pages/schedule/schedule.wxml
+++ b/pages/schedule/schedule.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd">
+<view class="page__bd {{themeClass}}">
 
   <view class="weui-navbar">
     <block wx:for="{{tabs}}" wx:key="*this">

--- a/pages/schedule/schedule.wxss
+++ b/pages/schedule/schedule.wxss
@@ -2,7 +2,7 @@
 
 page, .page, .page__bd {
   height: 100%;
-  background-color: #f8f8f8;
+  background-color: var(--color-bg-primary);
 }
 
 .page__bd {
@@ -11,7 +11,7 @@ page, .page, .page__bd {
 
 .weui-navbar {
   position: static;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 .weui-tab__panel {
@@ -27,7 +27,7 @@ page, .page, .page__bd {
   padding: 20rpx;
   margin-top: 20rpx;
   position: relative;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 .weui-media-box__info {
@@ -58,25 +58,25 @@ text + .weui-media-box__bold {
 }
 
 button[type="primary"][plain] {
-  color: #fff;
+  color: var(--color-surface);
   border: 1px solid #96deda;
   background-image: linear-gradient(-45deg, #96deda 0%, #8ec5fc 100%);
 }
 
 .button-hover[type="primary"][plain] {
-  color: #fff;
+  color: var(--color-surface);
   border-color: #96deda;
   opacity: 0.6;
 }
 
 button[type="default"][plain] {
-  color: #fff;
+  color: var(--color-surface);
   border: 1px solid #fbc2eb;
   background-image: linear-gradient(-45deg, #fbc2eb 0%, #a6c1ee 100%);
 }
 
 .button-hover[type="default"][plain] {
-  color: #fff;
+  color: var(--color-surface);
   border-color: #fbc2eb;
   opacity: 0.6;
 }

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -2,6 +2,7 @@ const { FEATURE_SECTIONS, FEATURE_MAP, MOCK_CREDENTIALS_HINT } = require('../../
 const auth = require('../../services/auth.js')
 const dataSource = require('../../services/data-source.js')
 const featureConfig = require('../../services/feature-config.js')
+var themeUtil = require('../../utils/theme')
 
 function buildFeatureSections() {
   const featureVisibility = featureConfig.getFeatureVisibility()
@@ -23,6 +24,7 @@ function buildFeatureSections() {
 
 Page({
   data: {
+    themeClass: '',
     useMockData: false,
     dataSourceLabel: '',
     mockCredentialsHint: MOCK_CREDENTIALS_HINT,
@@ -66,6 +68,7 @@ Page({
   },
 
   onShow: function() {
+    themeUtil.applyTheme(this)
     this.refreshPageState()
   }
 })

--- a/pages/settings/settings.wxml
+++ b/pages/settings/settings.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd">
+<view class="page__bd {{themeClass}}">
   <view class="weui-cells__title">数据源</view>
   <view class="weui-cells weui-cells_after-title">
     <view class="weui-cell weui-cell_switch">

--- a/pages/settings/settings.wxss
+++ b/pages/settings/settings.wxss
@@ -3,14 +3,14 @@
 .section_title {
   margin-top: 20rpx;
   padding: 0 30rpx;
-  color: #999;
+  color: var(--color-text-tertiary);
   font-size: 28rpx;
 }
 
 .mock_hint {
   display: block;
   margin: 20rpx 30rpx 0;
-  color: #888;
+  color: var(--color-text-secondary);
   text-align: center;
   font-size: 26rpx;
 }

--- a/pages/spare/spare.js
+++ b/pages/spare/spare.js
@@ -8,9 +8,14 @@ const {
 } = require('../../constants/spare.js')
 const infoApi = require('../../services/apis/info.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     campusOptions: SPARE_CAMPUS_OPTIONS,
     roomTypeOptions: SPARE_ROOM_TYPE_OPTIONS,
     weekDayOptions: SPARE_WEEKDAY_OPTIONS,

--- a/pages/spare/spare.wxml
+++ b/pages/spare/spare.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd">
+<view class="page__bd {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="container" wx:if="{{result == null}}">

--- a/pages/yellowPage/yellowPage.js
+++ b/pages/yellowPage/yellowPage.js
@@ -1,5 +1,6 @@
 const dataApi = require('../../services/apis/data.js')
 const pageUtils = require('../../utils/page.js')
+var themeUtil = require('../../utils/theme')
 
 function groupYellowPage(result) {
   const typeList = result.type || []
@@ -19,7 +20,11 @@ function groupYellowPage(result) {
 }
 
 Page({
+  onShow: function () {
+    themeUtil.applyTheme(this)
+  },
   data: {
+    themeClass: '',
     loading: false,
     groupedYellowPages: [],
     errorMessage: null

--- a/pages/yellowPage/yellowPage.wxml
+++ b/pages/yellowPage/yellowPage.wxml
@@ -1,4 +1,4 @@
-<view class="page__bd">
+<view class="page__bd {{themeClass}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <block wx:for="{{groupedYellowPages}}" wx:key="typeCode" wx:for-item="group">

--- a/pages/yellowPage/yellowPage.wxss
+++ b/pages/yellowPage/yellowPage.wxss
@@ -1,6 +1,6 @@
 @import "../../common/lib/weui.wxss";
 
 .item_meta {
-  color: #888;
+  color: var(--color-text-secondary);
   font-size: 24rpx;
 }

--- a/scripts/migrate-colors.js
+++ b/scripts/migrate-colors.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const path = require('path')
+
+const COLOR_MAP = {
+  '#F8F8F8': 'var(--color-bg-primary)',
+  '#f8f8f8': 'var(--color-bg-primary)',
+  '#f2f2f2': 'var(--color-bg-secondary)',
+  '#fbfbfb': 'var(--color-bg-secondary)',
+  '#f5f5f5': 'var(--color-bg-secondary)',
+  '#f0f0f0': 'var(--color-bg-secondary)',
+  '#ebebeb': 'var(--color-bg-tertiary)',
+  '#ffffff': 'var(--color-surface)',
+  '#fff': 'var(--color-surface)',
+  '#FFFFFF': 'var(--color-surface)',
+  '#333': 'var(--color-text-primary)',
+  '#333333': 'var(--color-text-primary)',
+  '#222': 'var(--color-text-primary)',
+  '#222222': 'var(--color-text-primary)',
+  '#666': 'var(--color-text-secondary)',
+  '#666666': 'var(--color-text-secondary)',
+  '#888': 'var(--color-text-secondary)',
+  '#888888': 'var(--color-text-secondary)',
+  '#999': 'var(--color-text-tertiary)',
+  '#999999': 'var(--color-text-tertiary)',
+  '#aaa': 'var(--color-text-tertiary)',
+  '#bbb': 'var(--color-text-tertiary)',
+  '#ececec': 'var(--color-divider)',
+  '#e3e3e3': 'var(--color-divider)',
+  '#dfdfdf': 'var(--color-border)',
+  '#1AAD19': 'var(--color-primary)',
+  '#1aad19': 'var(--color-primary)',
+  '#09bb07': 'var(--color-primary)',
+  '#e94747': 'var(--color-danger)',
+  '#576b95': 'var(--color-link)',
+  '#586c94': 'var(--color-link)',
+}
+
+const ROOT = path.join(__dirname, '..')
+const PAGES_DIR = path.join(ROOT, 'pages')
+const report = []
+
+function processFile(filePath) {
+  let content = fs.readFileSync(filePath, 'utf8')
+  let changed = false
+  for (const [hex, cssVar] of Object.entries(COLOR_MAP)) {
+    const escaped = hex.replace('#', '\\#')
+    const regex = new RegExp(escaped, 'g')
+    const lines = content.split('\n')
+    lines.forEach((line, idx) => {
+      if (regex.test(line)) {
+        report.push({ file: path.relative(ROOT, filePath), line: idx + 1, from: hex, to: cssVar })
+      }
+      regex.lastIndex = 0
+    })
+    const newContent = content.replace(regex, cssVar)
+    if (newContent !== content) {
+      content = newContent
+      changed = true
+    }
+  }
+  if (changed) fs.writeFileSync(filePath, content, 'utf8')
+  return changed
+}
+
+const wxssFiles = []
+function walkDir(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) walkDir(full)
+    else if (entry.name.endsWith('.wxss')) wxssFiles.push(full)
+  }
+}
+walkDir(PAGES_DIR)
+
+let totalChanged = 0
+for (const f of wxssFiles) {
+  if (processFile(f)) totalChanged++
+}
+
+console.log('\n=== Color Migration Report ===')
+console.log('Files scanned: ' + wxssFiles.length)
+console.log('Files modified: ' + totalChanged)
+console.log('Replacements: ' + report.length)
+console.log('')
+report.forEach(function(r) {
+  console.log('  ' + r.file + ':' + r.line + '  ' + r.from + ' -> ' + r.to)
+})

--- a/styles/theme.wxss
+++ b/styles/theme.wxss
@@ -1,0 +1,35 @@
+/* Theme CSS Variables — Light (default) and Dark */
+
+page {
+  --color-bg-primary: #F8F8F8;
+  --color-bg-secondary: #f2f2f2;
+  --color-bg-tertiary: #ebebeb;
+  --color-surface: #ffffff;
+  --color-surface-raised: #ffffff;
+  --color-text-primary: #333333;
+  --color-text-secondary: #666666;
+  --color-text-tertiary: #999999;
+  --color-border: #e5e7eb;
+  --color-divider: #ececec;
+  --color-primary: #1AAD19;
+  --color-primary-hover: #148a14;
+  --color-danger: #e94747;
+  --color-link: #576b95;
+}
+
+.theme-dark {
+  --color-bg-primary: #121212;
+  --color-bg-secondary: #1a1a1a;
+  --color-bg-tertiary: #242424;
+  --color-surface: #1e1e1e;
+  --color-surface-raised: #2a2a2a;
+  --color-text-primary: #e5e7eb;
+  --color-text-secondary: #9ca3af;
+  --color-text-tertiary: #9295a0;
+  --color-border: #374151;
+  --color-divider: #2a2a2a;
+  --color-primary: #34D399;
+  --color-primary-hover: #6EE7B7;
+  --color-danger: #ff7c7c;
+  --color-link: #60a5fa;
+}

--- a/utils/theme.js
+++ b/utils/theme.js
@@ -1,0 +1,71 @@
+var THEME_KEY = 'theme'
+var FONT_SCALE_KEY = 'font_scale_step'
+var FONT_SCALES = [0.85, 1.0, 1.15, 1.3]
+
+function getStoredThemeMode() {
+  try { return wx.getStorageSync(THEME_KEY) || 'system' } catch (e) { return 'system' }
+}
+
+function getSystemTheme() {
+  try { return wx.getSystemInfoSync().theme || 'light' } catch (e) { return 'light' }
+}
+
+function resolveEffective(mode) {
+  if (mode === 'light' || mode === 'dark') return mode
+  return getSystemTheme()
+}
+
+function getStoredFontScaleStep() {
+  try {
+    var v = parseInt(wx.getStorageSync(FONT_SCALE_KEY), 10)
+    return (v >= 0 && v <= 3) ? v : 1
+  } catch (e) { return 1 }
+}
+
+module.exports = {
+  FONT_SCALES: FONT_SCALES,
+
+  getThemeMode: getStoredThemeMode,
+
+  getEffectiveTheme: function () {
+    return resolveEffective(getStoredThemeMode())
+  },
+
+  setThemeMode: function (mode) {
+    wx.setStorageSync(THEME_KEY, mode)
+    var app = getApp()
+    app.globalData.theme = resolveEffective(mode)
+  },
+
+  getFontScaleStep: getStoredFontScaleStep,
+
+  getFontScale: function () {
+    return FONT_SCALES[getStoredFontScaleStep()] || 1.0
+  },
+
+  setFontScaleStep: function (step) {
+    wx.setStorageSync(FONT_SCALE_KEY, step)
+    var app = getApp()
+    app.globalData.fontScaleStep = step
+  },
+
+  applyTheme: function (pageInstance) {
+    var effective = resolveEffective(getStoredThemeMode())
+    pageInstance.setData({ themeClass: effective === 'dark' ? 'theme-dark' : '' })
+  },
+
+  initThemeListener: function () {
+    var self = this
+    wx.onThemeChange(function (res) {
+      var mode = getStoredThemeMode()
+      if (mode === 'system') {
+        var app = getApp()
+        app.globalData.theme = res.theme
+        var pages = getCurrentPages()
+        if (pages.length > 0) {
+          self.applyTheme(pages[pages.length - 1])
+        }
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- Add CSS variable theme system (styles/theme.wxss) with light/dark sets
- Batch migrate 125 hardcoded colors across 22 page WXSS files
- New Appearance page with theme switch, font slider, language picker
- Apply themeClass to all 26 pages with system theme listener
- Enable darkmode in app.json, add navigation entry
- Expanded README with architecture section
- 6-language i18n support

## Test plan
- [ ] Verify dark mode toggle in Appearance page
- [ ] Verify system theme change propagates to visible page
- [ ] Verify all pages have correct theme class
- [ ] Verify no corrupted CSS values from migration
- [ ] Test in WeChat DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)