### PR TITLE
fix: sync navigation bar color with dark mode

### DIFF
--- a/utils/theme.js
+++ b/utils/theme.js
@@ -52,6 +52,12 @@ module.exports = {
   applyTheme: function (pageInstance) {
     var effective = resolveEffective(getStoredThemeMode())
     pageInstance.setData({ themeClass: effective === 'dark' ? 'theme-dark' : '' })
+    // Sync navigation bar colors with theme
+    wx.setNavigationBarColor({
+      frontColor: effective === 'dark' ? '#ffffff' : '#000000',
+      backgroundColor: effective === 'dark' ? '#1e1e1e' : '#ffffff',
+      animation: { duration: 200, timingFunc: 'easeIn' }
+    })
   },
 
   initThemeListener: function () {


### PR DESCRIPTION
## Summary
- Add `wx.setNavigationBarColor()` call in `applyTheme()` to dynamically update nav bar for dark mode
- Dark mode: white text on #1e1e1e background
- Light mode: black text on white background

Found during design spec re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)