### PR TITLE
WeChat: 9 page nav titles + 5 page body i18n + schedule fallback

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -331,6 +331,33 @@
       "logout": { "title": "Logout", "desc": "Log out of current account" }
     }
   },
+  "billPage": {
+    "navTitle": "Card Transactions"
+  },
+  "bookPage": {
+    "navTitle": "My Loans"
+  },
+  "graduateExamPage": {
+    "navTitle": "Postgrad Exam"
+  },
+  "dataPage": {
+    "navTitle": "Data Query"
+  },
+  "cardLostPage": {
+    "navTitle": "Report Lost Card"
+  },
+  "electricityPage": {
+    "navTitle": "Electricity Bill"
+  },
+  "collectionPage": {
+    "navTitle": "Library"
+  },
+  "yellowPagePage": {
+    "navTitle": "Yellow Pages"
+  },
+  "evaluatePage": {
+    "navTitle": "Evaluation"
+  },
   "spare": {
     "campus": {
       "any": "Any",

--- a/locales/en.json
+++ b/locales/en.json
@@ -332,31 +332,87 @@
     }
   },
   "billPage": {
-    "navTitle": "Card Transactions"
+    "navTitle": "Card Transactions",
+    "selectDateHint": "Select a date to query",
+    "dateLabel": "Date",
+    "notSelected": "Not selected",
+    "queryButton": "Query",
+    "noRecords": "No transaction records",
+    "recordsTitle": "Transaction Records",
+    "yuan": " CNY",
+    "reQuery": "Query Again",
+    "shareTitle": "Card Transactions"
   },
   "bookPage": {
     "navTitle": "My Loans"
   },
   "graduateExamPage": {
-    "navTitle": "Postgrad Exam"
+    "navTitle": "Postgrad Exam",
+    "queryInfo": "Query Info",
+    "nameLabel": "Name",
+    "namePlaceholder": "Enter your name",
+    "examNumberLabel": "Ticket No.",
+    "examNumberPlaceholder": "Enter admission ticket number",
+    "idNumberLabel": "ID Number",
+    "idNumberPlaceholder": "Enter ID number",
+    "queryButton": "Query",
+    "fillAllFields": "Please fill in all query fields",
+    "resultTitle": "Exam Results",
+    "resultName": "Name",
+    "signUpNumber": "Registration No.",
+    "resultExamNumber": "Ticket No.",
+    "totalScore": "Total",
+    "firstScore": "Subject 1",
+    "secondScore": "Subject 2",
+    "thirdScore": "Subject 3",
+    "fourthScore": "Subject 4",
+    "reQuery": "Query Again",
+    "shareTitle": "Postgrad Exam"
   },
   "dataPage": {
     "navTitle": "Data Query"
   },
   "cardLostPage": {
-    "navTitle": "Report Lost Card"
+    "navTitle": "Report Lost Card",
+    "passwordLabel": "Password",
+    "passwordPlaceholder": "Enter 6-digit card password",
+    "passwordValidation": "Please enter a valid 6-digit card password",
+    "reportButton": "Report Lost",
+    "warning": "Note: After reporting lost, please visit the card office to get a replacement",
+    "successTitle": "Reported Successfully",
+    "successContent": "Please visit the card office to get a replacement card as soon as possible",
+    "shareTitle": "Report Lost Card"
   },
   "electricityPage": {
     "navTitle": "Electricity Bill"
   },
   "collectionPage": {
-    "navTitle": "Library"
+    "navTitle": "Library",
+    "myLoans": "My Loans",
+    "myLoansDesc": "View loan records and renew books",
+    "bookNameLabel": "Book",
+    "bookNamePlaceholder": "Enter book information",
+    "bookNameValidation": "Please enter a book name to search",
+    "queryButton": "Search",
+    "noBooks": "No matching books found",
+    "queryResult": "Search Results",
+    "loadMore": "Load more",
+    "noMoreBooks": "No more books",
+    "loadingData": "Loading",
+    "shareTitle": "Library"
   },
   "yellowPagePage": {
     "navTitle": "Yellow Pages"
   },
   "evaluatePage": {
-    "navTitle": "Evaluation"
+    "navTitle": "Evaluation",
+    "autoSubmitTitle": "Auto Submit",
+    "autoSubmitLabel": "Submit evaluation directly",
+    "submitButton": "Submit",
+    "successTitle": "Evaluation Successful",
+    "successWithSubmit": "Evaluation completed and submitted successfully",
+    "successWithoutSubmit": "Evaluation completed. Please log in to the academic system to confirm",
+    "shareTitle": "Teaching Evaluation"
   },
   "spare": {
     "campus": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -332,31 +332,87 @@
     }
   },
   "billPage": {
-    "navTitle": "学生証利用履歴"
+    "navTitle": "学生証利用履歴",
+    "selectDateHint": "照会する日付を選択してください",
+    "dateLabel": "日付",
+    "notSelected": "未選択",
+    "queryButton": "検索",
+    "noRecords": "利用履歴はありません",
+    "recordsTitle": "利用履歴",
+    "yuan": "元",
+    "reQuery": "再検索",
+    "shareTitle": "学生証利用履歴"
   },
   "bookPage": {
     "navTitle": "マイ貸出"
   },
   "graduateExamPage": {
-    "navTitle": "大学院入試照会"
+    "navTitle": "大学院入試照会",
+    "queryInfo": "検索情報",
+    "nameLabel": "氏名",
+    "namePlaceholder": "氏名を入力",
+    "examNumberLabel": "受験番号",
+    "examNumberPlaceholder": "受験番号を入力",
+    "idNumberLabel": "証明書番号",
+    "idNumberPlaceholder": "証明書番号を入力",
+    "queryButton": "検索",
+    "fillAllFields": "すべての検索項目を入力してください",
+    "resultTitle": "大学院入試成績",
+    "resultName": "氏名",
+    "signUpNumber": "登録番号",
+    "resultExamNumber": "受験番号",
+    "totalScore": "合計",
+    "firstScore": "科目1",
+    "secondScore": "科目2",
+    "thirdScore": "科目3",
+    "fourthScore": "科目4",
+    "reQuery": "再検索",
+    "shareTitle": "大学院入試照会"
   },
   "dataPage": {
     "navTitle": "データ照会"
   },
   "cardLostPage": {
-    "navTitle": "紛失届"
+    "navTitle": "紛失届",
+    "passwordLabel": "パスワード",
+    "passwordPlaceholder": "6桁のカードパスワードを入力",
+    "passwordValidation": "正しい6桁のカードパスワードを入力してください",
+    "reportButton": "紛失届出",
+    "warning": "注意：届出後、カード発行窓口で再発行手続きが必要です",
+    "successTitle": "届出完了",
+    "successContent": "できるだけ早くカード発行窓口で再発行手続きをしてください",
+    "shareTitle": "紛失届"
   },
   "electricityPage": {
     "navTitle": "電気料金照会"
   },
   "collectionPage": {
-    "navTitle": "図書館"
+    "navTitle": "図書館",
+    "myLoans": "マイ貸出",
+    "myLoansDesc": "貸出記録の確認と更新",
+    "bookNameLabel": "書名",
+    "bookNamePlaceholder": "図書情報を入力",
+    "bookNameValidation": "検索する書名を入力してください",
+    "queryButton": "検索",
+    "noBooks": "該当する図書が見つかりません",
+    "queryResult": "検索結果",
+    "loadMore": "もっと読み込む",
+    "noMoreBooks": "これ以上の図書情報はありません",
+    "loadingData": "読み込み中",
+    "shareTitle": "図書館"
   },
   "yellowPagePage": {
     "navTitle": "電話帳検索"
   },
   "evaluatePage": {
-    "navTitle": "授業評価"
+    "navTitle": "授業評価",
+    "autoSubmitTitle": "自動送信",
+    "autoSubmitLabel": "評価情報を直接送信",
+    "submitButton": "送信",
+    "successTitle": "評価完了",
+    "successWithSubmit": "評価が完了し、情報が送信されました",
+    "successWithoutSubmit": "評価が完了しました。教務システムにログインして最終確認してください",
+    "shareTitle": "授業評価"
   },
   "spare": {
     "campus": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -331,6 +331,33 @@
       "logout": { "title": "ログアウト", "desc": "現在のアカウントからログアウト" }
     }
   },
+  "billPage": {
+    "navTitle": "学生証利用履歴"
+  },
+  "bookPage": {
+    "navTitle": "マイ貸出"
+  },
+  "graduateExamPage": {
+    "navTitle": "大学院入試照会"
+  },
+  "dataPage": {
+    "navTitle": "データ照会"
+  },
+  "cardLostPage": {
+    "navTitle": "紛失届"
+  },
+  "electricityPage": {
+    "navTitle": "電気料金照会"
+  },
+  "collectionPage": {
+    "navTitle": "図書館"
+  },
+  "yellowPagePage": {
+    "navTitle": "電話帳検索"
+  },
+  "evaluatePage": {
+    "navTitle": "授業評価"
+  },
   "spare": {
     "campus": {
       "any": "指定なし",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -331,6 +331,33 @@
       "logout": { "title": "로그아웃", "desc": "현재 계정에서 로그아웃" }
     }
   },
+  "billPage": {
+    "navTitle": "학생증 거래 내역"
+  },
+  "bookPage": {
+    "navTitle": "내 대출"
+  },
+  "graduateExamPage": {
+    "navTitle": "대학원 시험 조회"
+  },
+  "dataPage": {
+    "navTitle": "데이터 조회"
+  },
+  "cardLostPage": {
+    "navTitle": "분실 신고"
+  },
+  "electricityPage": {
+    "navTitle": "전기요금 조회"
+  },
+  "collectionPage": {
+    "navTitle": "도서관"
+  },
+  "yellowPagePage": {
+    "navTitle": "전화번호부 검색"
+  },
+  "evaluatePage": {
+    "navTitle": "수업 평가"
+  },
   "spare": {
     "campus": {
       "any": "전체",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -332,31 +332,87 @@
     }
   },
   "billPage": {
-    "navTitle": "학생증 거래 내역"
+    "navTitle": "학생증 거래 내역",
+    "selectDateHint": "조회할 날짜를 선택하세요",
+    "dateLabel": "날짜",
+    "notSelected": "미선택",
+    "queryButton": "조회",
+    "noRecords": "거래 내역이 없습니다",
+    "recordsTitle": "거래 내역",
+    "yuan": "위안",
+    "reQuery": "다시 조회",
+    "shareTitle": "학생증 거래 내역"
   },
   "bookPage": {
     "navTitle": "내 대출"
   },
   "graduateExamPage": {
-    "navTitle": "대학원 시험 조회"
+    "navTitle": "대학원 시험 조회",
+    "queryInfo": "조회 정보",
+    "nameLabel": "이름",
+    "namePlaceholder": "이름을 입력하세요",
+    "examNumberLabel": "수험번호",
+    "examNumberPlaceholder": "수험번호를 입력하세요",
+    "idNumberLabel": "신분증 번호",
+    "idNumberPlaceholder": "신분증 번호를 입력하세요",
+    "queryButton": "조회",
+    "fillAllFields": "모든 조회 정보를 입력하세요",
+    "resultTitle": "대학원 시험 성적",
+    "resultName": "이름",
+    "signUpNumber": "접수번호",
+    "resultExamNumber": "수험번호",
+    "totalScore": "총점",
+    "firstScore": "과목 1",
+    "secondScore": "과목 2",
+    "thirdScore": "과목 3",
+    "fourthScore": "과목 4",
+    "reQuery": "다시 조회",
+    "shareTitle": "대학원 시험 조회"
   },
   "dataPage": {
     "navTitle": "데이터 조회"
   },
   "cardLostPage": {
-    "navTitle": "분실 신고"
+    "navTitle": "분실 신고",
+    "passwordLabel": "비밀번호",
+    "passwordPlaceholder": "6자리 카드 비밀번호 입력",
+    "passwordValidation": "올바른 6자리 카드 비밀번호를 입력하세요",
+    "reportButton": "분실 신고",
+    "warning": "주의: 분실 신고 후 카드 발급처에서 재발급 받아야 합니다",
+    "successTitle": "신고 완료",
+    "successContent": "가능한 빨리 카드 발급처에서 재발급 받으세요",
+    "shareTitle": "분실 신고"
   },
   "electricityPage": {
     "navTitle": "전기요금 조회"
   },
   "collectionPage": {
-    "navTitle": "도서관"
+    "navTitle": "도서관",
+    "myLoans": "내 대출",
+    "myLoansDesc": "대출 기록 확인 및 연장",
+    "bookNameLabel": "도서명",
+    "bookNamePlaceholder": "도서 정보를 입력하세요",
+    "bookNameValidation": "검색할 도서명을 입력하세요",
+    "queryButton": "검색",
+    "noBooks": "해당 도서를 찾을 수 없습니다",
+    "queryResult": "검색 결과",
+    "loadMore": "더 불러오기",
+    "noMoreBooks": "더 이상 도서 정보가 없습니다",
+    "loadingData": "로딩 중",
+    "shareTitle": "도서관"
   },
   "yellowPagePage": {
     "navTitle": "전화번호부 검색"
   },
   "evaluatePage": {
-    "navTitle": "수업 평가"
+    "navTitle": "수업 평가",
+    "autoSubmitTitle": "자동 제출",
+    "autoSubmitLabel": "평가 정보 바로 제출",
+    "submitButton": "제출",
+    "successTitle": "평가 완료",
+    "successWithSubmit": "평가가 완료되어 정보가 제출되었습니다",
+    "successWithoutSubmit": "평가가 완료되었습니다. 교무 시스템에 로그인하여 최종 확인하세요",
+    "shareTitle": "수업 평가"
   },
   "spare": {
     "campus": {

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -331,6 +331,33 @@
       "logout": { "title": "退出账号", "desc": "退出当前账号" }
     }
   },
+  "billPage": {
+    "navTitle": "校园卡消费"
+  },
+  "bookPage": {
+    "navTitle": "我的借阅"
+  },
+  "graduateExamPage": {
+    "navTitle": "考研查询"
+  },
+  "dataPage": {
+    "navTitle": "数据查询"
+  },
+  "cardLostPage": {
+    "navTitle": "校园卡挂失"
+  },
+  "electricityPage": {
+    "navTitle": "电费查询"
+  },
+  "collectionPage": {
+    "navTitle": "图书馆"
+  },
+  "yellowPagePage": {
+    "navTitle": "黄页查询"
+  },
+  "evaluatePage": {
+    "navTitle": "一键评教"
+  },
   "spare": {
     "campus": {
       "any": "不限",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -332,31 +332,87 @@
     }
   },
   "billPage": {
-    "navTitle": "校园卡消费"
+    "navTitle": "校园卡消费",
+    "selectDateHint": "请选择查询日期",
+    "dateLabel": "日期",
+    "notSelected": "未选择",
+    "queryButton": "查询",
+    "noRecords": "没有消费记录",
+    "recordsTitle": "消费记录",
+    "yuan": "元",
+    "reQuery": "重新查询",
+    "shareTitle": "校园卡消费"
   },
   "bookPage": {
     "navTitle": "我的借阅"
   },
   "graduateExamPage": {
-    "navTitle": "考研查询"
+    "navTitle": "考研查询",
+    "queryInfo": "查询信息",
+    "nameLabel": "姓名",
+    "namePlaceholder": "请输入姓名",
+    "examNumberLabel": "考号",
+    "examNumberPlaceholder": "请输入准考证号",
+    "idNumberLabel": "证件号",
+    "idNumberPlaceholder": "请输入证件号",
+    "queryButton": "查询",
+    "fillAllFields": "请完整填写考研查询信息",
+    "resultTitle": "考研成绩",
+    "resultName": "姓名",
+    "signUpNumber": "报名号",
+    "resultExamNumber": "准考证号",
+    "totalScore": "总分",
+    "firstScore": "科目一",
+    "secondScore": "科目二",
+    "thirdScore": "科目三",
+    "fourthScore": "科目四",
+    "reQuery": "重新查询",
+    "shareTitle": "考研查询"
   },
   "dataPage": {
     "navTitle": "数据查询"
   },
   "cardLostPage": {
-    "navTitle": "校园卡挂失"
+    "navTitle": "校园卡挂失",
+    "passwordLabel": "密码",
+    "passwordPlaceholder": "请输入6位校园卡密码",
+    "passwordValidation": "请输入正确的校园卡查询密码",
+    "reportButton": "挂失",
+    "warning": "注意：挂失后需要到办卡处进行补办校园卡",
+    "successTitle": "挂失成功",
+    "successContent": "请尽快前往办卡处进行校园卡补办",
+    "shareTitle": "校园卡挂失"
   },
   "electricityPage": {
     "navTitle": "电费查询"
   },
   "collectionPage": {
-    "navTitle": "图书馆"
+    "navTitle": "图书馆",
+    "myLoans": "我的借阅",
+    "myLoansDesc": "查询借阅记录并完成续借",
+    "bookNameLabel": "书名",
+    "bookNamePlaceholder": "请输入图书信息",
+    "bookNameValidation": "请填写要查询的书名",
+    "queryButton": "查询",
+    "noBooks": "没有找到对应的图书信息",
+    "queryResult": "查询结果",
+    "loadMore": "点击加载更多信息",
+    "noMoreBooks": "没有更多图书信息",
+    "loadingData": "数据加载中",
+    "shareTitle": "图书馆"
   },
   "yellowPagePage": {
     "navTitle": "黄页查询"
   },
   "evaluatePage": {
-    "navTitle": "一键评教"
+    "navTitle": "一键评教",
+    "autoSubmitTitle": "自动提交",
+    "autoSubmitLabel": "直接提交评教信息",
+    "submitButton": "提交",
+    "successTitle": "一键评教成功",
+    "successWithSubmit": "一键评教成功，评教信息已提交",
+    "successWithoutSubmit": "一键评教成功，请登录教务系统进行最终确认",
+    "shareTitle": "教学评价"
   },
   "spare": {
     "campus": {

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -332,31 +332,87 @@
     }
   },
   "billPage": {
-    "navTitle": "校園卡消費"
+    "navTitle": "校園卡消費",
+    "selectDateHint": "請選擇查詢日期",
+    "dateLabel": "日期",
+    "notSelected": "未選擇",
+    "queryButton": "查詢",
+    "noRecords": "沒有消費記錄",
+    "recordsTitle": "消費記錄",
+    "yuan": "元",
+    "reQuery": "重新查詢",
+    "shareTitle": "校園卡消費"
   },
   "bookPage": {
     "navTitle": "我的借閱"
   },
   "graduateExamPage": {
-    "navTitle": "考研查詢"
+    "navTitle": "考研查詢",
+    "queryInfo": "查詢資訊",
+    "nameLabel": "姓名",
+    "namePlaceholder": "請輸入姓名",
+    "examNumberLabel": "考號",
+    "examNumberPlaceholder": "請輸入准考證號",
+    "idNumberLabel": "證件號",
+    "idNumberPlaceholder": "請輸入證件號",
+    "queryButton": "查詢",
+    "fillAllFields": "請完整填寫考研查詢資訊",
+    "resultTitle": "考研成績",
+    "resultName": "姓名",
+    "signUpNumber": "報名號",
+    "resultExamNumber": "准考證號",
+    "totalScore": "總分",
+    "firstScore": "科目一",
+    "secondScore": "科目二",
+    "thirdScore": "科目三",
+    "fourthScore": "科目四",
+    "reQuery": "重新查詢",
+    "shareTitle": "考研查詢"
   },
   "dataPage": {
     "navTitle": "數據查詢"
   },
   "cardLostPage": {
-    "navTitle": "校園卡掛失"
+    "navTitle": "校園卡掛失",
+    "passwordLabel": "密碼",
+    "passwordPlaceholder": "請輸入6位校園卡密碼",
+    "passwordValidation": "請輸入正確的校園卡查詢密碼",
+    "reportButton": "掛失",
+    "warning": "注意：掛失後需要到辦卡處進行補辦校園卡",
+    "successTitle": "掛失成功",
+    "successContent": "請儘快前往辦卡處進行校園卡補辦",
+    "shareTitle": "校園卡掛失"
   },
   "electricityPage": {
     "navTitle": "電費查詢"
   },
   "collectionPage": {
-    "navTitle": "圖書館"
+    "navTitle": "圖書館",
+    "myLoans": "我的借閱",
+    "myLoansDesc": "查詢借閱記錄並完成續借",
+    "bookNameLabel": "書名",
+    "bookNamePlaceholder": "請輸入圖書資訊",
+    "bookNameValidation": "請填寫要查詢的書名",
+    "queryButton": "查詢",
+    "noBooks": "沒有找到對應的圖書資訊",
+    "queryResult": "查詢結果",
+    "loadMore": "點擊載入更多資訊",
+    "noMoreBooks": "沒有更多圖書資訊",
+    "loadingData": "數據載入中",
+    "shareTitle": "圖書館"
   },
   "yellowPagePage": {
     "navTitle": "黃頁查詢"
   },
   "evaluatePage": {
-    "navTitle": "一鍵評教"
+    "navTitle": "一鍵評教",
+    "autoSubmitTitle": "自動提交",
+    "autoSubmitLabel": "直接提交評教資訊",
+    "submitButton": "提交",
+    "successTitle": "一鍵評教成功",
+    "successWithSubmit": "一鍵評教成功，評教資訊已提交",
+    "successWithoutSubmit": "一鍵評教成功，請登入教務系統進行最終確認",
+    "shareTitle": "教學評價"
   },
   "spare": {
     "campus": {

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -331,6 +331,33 @@
       "logout": { "title": "登出賬號", "desc": "登出當前賬號" }
     }
   },
+  "billPage": {
+    "navTitle": "校園卡消費"
+  },
+  "bookPage": {
+    "navTitle": "我的借閱"
+  },
+  "graduateExamPage": {
+    "navTitle": "考研查詢"
+  },
+  "dataPage": {
+    "navTitle": "數據查詢"
+  },
+  "cardLostPage": {
+    "navTitle": "校園卡掛失"
+  },
+  "electricityPage": {
+    "navTitle": "電費查詢"
+  },
+  "collectionPage": {
+    "navTitle": "圖書館"
+  },
+  "yellowPagePage": {
+    "navTitle": "黃頁查詢"
+  },
+  "evaluatePage": {
+    "navTitle": "一鍵評教"
+  },
   "spare": {
     "campus": {
       "any": "不限",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -331,6 +331,33 @@
       "logout": { "title": "登出帳號", "desc": "登出目前帳號" }
     }
   },
+  "billPage": {
+    "navTitle": "校園卡消費"
+  },
+  "bookPage": {
+    "navTitle": "我的借閱"
+  },
+  "graduateExamPage": {
+    "navTitle": "考研查詢"
+  },
+  "dataPage": {
+    "navTitle": "資料查詢"
+  },
+  "cardLostPage": {
+    "navTitle": "校園卡掛失"
+  },
+  "electricityPage": {
+    "navTitle": "電費查詢"
+  },
+  "collectionPage": {
+    "navTitle": "圖書館"
+  },
+  "yellowPagePage": {
+    "navTitle": "黃頁查詢"
+  },
+  "evaluatePage": {
+    "navTitle": "一鍵評量"
+  },
   "spare": {
     "campus": {
       "any": "不限",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -332,31 +332,87 @@
     }
   },
   "billPage": {
-    "navTitle": "校園卡消費"
+    "navTitle": "校園卡消費",
+    "selectDateHint": "請選擇查詢日期",
+    "dateLabel": "日期",
+    "notSelected": "未選擇",
+    "queryButton": "查詢",
+    "noRecords": "沒有消費紀錄",
+    "recordsTitle": "消費紀錄",
+    "yuan": "元",
+    "reQuery": "重新查詢",
+    "shareTitle": "校園卡消費"
   },
   "bookPage": {
     "navTitle": "我的借閱"
   },
   "graduateExamPage": {
-    "navTitle": "考研查詢"
+    "navTitle": "考研查詢",
+    "queryInfo": "查詢資訊",
+    "nameLabel": "姓名",
+    "namePlaceholder": "請輸入姓名",
+    "examNumberLabel": "考號",
+    "examNumberPlaceholder": "請輸入准考證號",
+    "idNumberLabel": "證件號",
+    "idNumberPlaceholder": "請輸入證件號",
+    "queryButton": "查詢",
+    "fillAllFields": "請完整填寫考研查詢資訊",
+    "resultTitle": "考研成績",
+    "resultName": "姓名",
+    "signUpNumber": "報名號",
+    "resultExamNumber": "准考證號",
+    "totalScore": "總分",
+    "firstScore": "科目一",
+    "secondScore": "科目二",
+    "thirdScore": "科目三",
+    "fourthScore": "科目四",
+    "reQuery": "重新查詢",
+    "shareTitle": "考研查詢"
   },
   "dataPage": {
     "navTitle": "資料查詢"
   },
   "cardLostPage": {
-    "navTitle": "校園卡掛失"
+    "navTitle": "校園卡掛失",
+    "passwordLabel": "密碼",
+    "passwordPlaceholder": "請輸入6位校園卡密碼",
+    "passwordValidation": "請輸入正確的校園卡查詢密碼",
+    "reportButton": "掛失",
+    "warning": "注意：掛失後需要到辦卡處進行補辦校園卡",
+    "successTitle": "掛失成功",
+    "successContent": "請儘快前往辦卡處進行校園卡補辦",
+    "shareTitle": "校園卡掛失"
   },
   "electricityPage": {
     "navTitle": "電費查詢"
   },
   "collectionPage": {
-    "navTitle": "圖書館"
+    "navTitle": "圖書館",
+    "myLoans": "我的借閱",
+    "myLoansDesc": "查詢借閱紀錄並完成續借",
+    "bookNameLabel": "書名",
+    "bookNamePlaceholder": "請輸入圖書資訊",
+    "bookNameValidation": "請填寫要查詢的書名",
+    "queryButton": "查詢",
+    "noBooks": "沒有找到對應的圖書資訊",
+    "queryResult": "查詢結果",
+    "loadMore": "點擊載入更多資訊",
+    "noMoreBooks": "沒有更多圖書資訊",
+    "loadingData": "資料載入中",
+    "shareTitle": "圖書館"
   },
   "yellowPagePage": {
     "navTitle": "黃頁查詢"
   },
   "evaluatePage": {
-    "navTitle": "一鍵評量"
+    "navTitle": "一鍵評量",
+    "autoSubmitTitle": "自動送出",
+    "autoSubmitLabel": "直接送出評量資訊",
+    "submitButton": "送出",
+    "successTitle": "一鍵評量成功",
+    "successWithSubmit": "一鍵評量成功，評量資訊已送出",
+    "successWithoutSubmit": "一鍵評量成功，請登入教務系統進行最終確認",
+    "shareTitle": "教學評量"
   },
   "spare": {
     "campus": {

--- a/pages/bill/bill.js
+++ b/pages/bill/bill.js
@@ -12,7 +12,17 @@ Page({
   refreshI18n: function () {
     this.setData({
       t: {
-        navTitle: i18n.t('billPage.navTitle')
+        navTitle: i18n.t('billPage.navTitle'),
+        selectDateHint: i18n.t('billPage.selectDateHint'),
+        dateLabel: i18n.t('billPage.dateLabel'),
+        notSelected: i18n.t('billPage.notSelected'),
+        queryButton: i18n.t('billPage.queryButton'),
+        noRecords: i18n.t('billPage.noRecords'),
+        recordsTitle: i18n.t('billPage.recordsTitle'),
+        yuan: i18n.t('billPage.yuan'),
+        reQuery: i18n.t('billPage.reQuery'),
+        queryFailed: i18n.t('common.queryFailed'),
+        shareTitle: i18n.t('billPage.shareTitle')
       }
     })
     wx.setNavigationBarTitle({ title: this.data.t.navTitle })
@@ -38,7 +48,7 @@ Page({
 
   submit: function() {
     if (!this.data.date) {
-      pageUtils.showTopTips(this, '请选择需要查询的日期')
+      pageUtils.showTopTips(this, i18n.t('billPage.selectDateHint'))
       return
     }
 
@@ -50,10 +60,10 @@ Page({
       if (result.success) {
         this.setData({ result: result.data.cardList })
       } else {
-        utils.showModal('查询失败', result.message)
+        utils.showModal(i18n.t('common.queryFailed'), result.message)
       }
     }).catch((error) => {
-      utils.showModal('查询失败', error.message)
+      utils.showModal(i18n.t('common.queryFailed'), error.message)
     })
   },
 
@@ -72,7 +82,7 @@ Page({
 
   onShareAppMessage: function() {
     return {
-      title: '校园卡消费',
+      title: i18n.t('billPage.shareTitle'),
       path: '/pages/bill/bill'
     }
   }

--- a/pages/bill/bill.js
+++ b/pages/bill/bill.js
@@ -2,13 +2,24 @@ const utils = require('../../utils/util.js')
 const campusApi = require('../../services/apis/campus.js')
 const pageUtils = require('../../utils/page.js')
 var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
 
 Page({
   onShow: function () {
     themeUtil.applyTheme(this)
+    this.refreshI18n()
+  },
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        navTitle: i18n.t('billPage.navTitle')
+      }
+    })
+    wx.setNavigationBarTitle({ title: this.data.t.navTitle })
   },
   data: {
     themeClass: '',
+    t: {},
     date: null,
     start: null,
     end: null,

--- a/pages/bill/bill.wxml
+++ b/pages/bill/bill.wxml
@@ -6,17 +6,17 @@
 
     <view block class="page__bd" wx:if="{{!result}}">
 
-      <view class="weui-cells__title">请选择查询日期</view>
+      <view class="weui-cells__title">{{t.selectDateHint}}</view>
       <view class="weui-cells weui-cells_after-title">
 
         <view class="weui-cell weui-cell_input">
           <view class="weui-cell__hd">
-            <view class="weui-label">日期</view>
+            <view class="weui-label">{{t.dateLabel}}</view>
           </view>
           <view class="weui-cell__bd">
             <picker mode="date" value="{{date}}" start="{{start}}" end="{{end}}" bindchange="bindDateChange">
               <view class="weui-input" wx:if="{{date}}">{{date}}</view>
-              <view class="weui-input" wx:if="{{!date}}">未选择</view>
+              <view class="weui-input" wx:if="{{!date}}">{{t.notSelected}}</view>
             </picker>
           </view>
         </view>
@@ -24,24 +24,24 @@
       </view>
 
       <view class="weui-btn-area">
-        <button class="weui-btn" disabled="{{loading}}" type="primary" bindtap="submit">查询</button>
+        <button class="weui-btn" disabled="{{loading}}" type="primary" bindtap="submit">{{t.queryButton}}</button>
       </view>
 
     </view>
 
     <view block class="page__bd" wx:if="{{result}}">
-      <view class="weui-cells__title" wx:if="{{result.length==0}}">没有消费记录</view>
-      <view class="weui-cells__title" wx:if="{{result.length!=0}}">消费记录</view>
+      <view class="weui-cells__title" wx:if="{{result.length==0}}">{{t.noRecords}}</view>
+      <view class="weui-cells__title" wx:if="{{result.length!=0}}">{{t.recordsTitle}}</view>
       <view class="weui-cells weui-cells_after-title">
         <view class="weui-cell" wx:for="{{result}}" wx:for-item="item" wx:key="item-key">
           <view class="weui-cell__bd">{{item.merchantName}}{{item.tradeName}}</view>
-          <view class="weui-cell__ft" wx:if="{{item.tradePrice <  0}}">{{item.tradePrice}}元</view>
-          <view class="weui-cell__ft" wx:if="{{item.tradePrice >= 0}}">+{{item.tradePrice}}元</view>
+          <view class="weui-cell__ft" wx:if="{{item.tradePrice <  0}}">{{item.tradePrice}}{{t.yuan}}</view>
+          <view class="weui-cell__ft" wx:if="{{item.tradePrice >= 0}}">+{{item.tradePrice}}{{t.yuan}}</view>
           </view>
         </view>
 
         <view class="weui-btn-area">
-          <button class="weui-btn" type="primary" bindtap="reset">重新查询</button>
+          <button class="weui-btn" type="primary" bindtap="reset">{{t.reQuery}}</button>
         </view>
 
       </view>

--- a/pages/book/book.js
+++ b/pages/book/book.js
@@ -2,13 +2,24 @@ const utils = require('../../utils/util.js')
 const libraryApi = require('../../services/apis/library.js')
 const pageUtils = require('../../utils/page.js')
 var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
 
 Page({
   onShow: function () {
     themeUtil.applyTheme(this)
+    this.refreshI18n()
+  },
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        navTitle: i18n.t('bookPage.navTitle')
+      }
+    })
+    wx.setNavigationBarTitle({ title: this.data.t.navTitle })
   },
   data: {
     themeClass: '',
+    t: {},
     password: '',
     result: [],
     hasQueriedBorrow: false,

--- a/pages/cardLost/cardLost.js
+++ b/pages/cardLost/cardLost.js
@@ -1,13 +1,24 @@
 const campusApi = require('../../services/apis/campus.js')
 const pageUtils = require('../../utils/page.js')
 var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
 
 Page({
   onShow: function () {
     themeUtil.applyTheme(this)
+    this.refreshI18n()
+  },
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        navTitle: i18n.t('cardLostPage.navTitle')
+      }
+    })
+    wx.setNavigationBarTitle({ title: this.data.t.navTitle })
   },
   data: {
     themeClass: '',
+    t: {},
     loading: false,
     errorMessage: null
   },

--- a/pages/cardLost/cardLost.js
+++ b/pages/cardLost/cardLost.js
@@ -11,7 +11,15 @@ Page({
   refreshI18n: function () {
     this.setData({
       t: {
-        navTitle: i18n.t('cardLostPage.navTitle')
+        navTitle: i18n.t('cardLostPage.navTitle'),
+        passwordLabel: i18n.t('cardLostPage.passwordLabel'),
+        passwordPlaceholder: i18n.t('cardLostPage.passwordPlaceholder'),
+        passwordValidation: i18n.t('cardLostPage.passwordValidation'),
+        reportButton: i18n.t('cardLostPage.reportButton'),
+        warning: i18n.t('cardLostPage.warning'),
+        successTitle: i18n.t('cardLostPage.successTitle'),
+        successContent: i18n.t('cardLostPage.successContent'),
+        shareTitle: i18n.t('cardLostPage.shareTitle')
       }
     })
     wx.setNavigationBarTitle({ title: this.data.t.navTitle })
@@ -26,7 +34,7 @@ Page({
   setCardLost: function(e) {
     const cardPassword = e.detail.value.password
     if (!(cardPassword && cardPassword.length === 6 && /^\d+$/.test(cardPassword))) {
-      pageUtils.showTopTips(this, '请输入正确的校园卡查询密码')
+      pageUtils.showTopTips(this, i18n.t('cardLostPage.passwordValidation'))
       return
     }
 
@@ -35,8 +43,8 @@ Page({
     }).then((result) => {
       if (result.success) {
         wx.showModal({
-          title: '挂失成功',
-          content: '请尽快前往办卡处进行校园卡补办',
+          title: i18n.t('cardLostPage.successTitle'),
+          content: i18n.t('cardLostPage.successContent'),
           showCancel: false
         })
       } else {
@@ -49,7 +57,7 @@ Page({
 
   onShareAppMessage: function() {
     return {
-      title: '校园卡挂失',
+      title: i18n.t('cardLostPage.shareTitle'),
       path: '/pages/cardLost/cardLost'
     }
   }

--- a/pages/cardLost/cardLost.wxml
+++ b/pages/cardLost/cardLost.wxml
@@ -10,22 +10,22 @@
         <view class="weui-cells weui-cells_after-title">
           <view class="weui-cell weui-cell_input weui-cell_vcode">
             <view class="weui-cell__hd">
-              <view class="weui-label">密码</view>
+              <view class="weui-label">{{t.passwordLabel}}</view>
             </view>
             <view class="weui-cell__bd">
-              <input name="password" class="weui-input" maxlength='6' password type="number" placeholder="请输入6位校园卡密码" />
+              <input name="password" class="weui-input" maxlength='6' password type="number" placeholder="{{t.passwordPlaceholder}}" />
             </view>
           </view>
         </view>
       </view>
 
       <view class="btn-area">
-        <button type="primary" disabled="{{loading}}" formType="submit">挂失</button>
+        <button type="primary" disabled="{{loading}}" formType="submit">{{t.reportButton}}</button>
       </view>
 
     </form>
 
-    <text class='lost_warning'>注意：挂失后需要到办卡处进行补办校园卡</text>
+    <text class='lost_warning'>{{t.warning}}</text>
 
   </view>
 

--- a/pages/collection/collection.js
+++ b/pages/collection/collection.js
@@ -1,13 +1,24 @@
 const libraryApi = require('../../services/apis/library.js')
 const pageUtils = require('../../utils/page.js')
 var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
 
 Page({
   onShow: function () {
     themeUtil.applyTheme(this)
+    this.refreshI18n()
+  },
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        navTitle: i18n.t('collectionPage.navTitle')
+      }
+    })
+    wx.setNavigationBarTitle({ title: this.data.t.navTitle })
   },
   data: {
     themeClass: '',
+    t: {},
     list: [],
     keyword: null,
     currentPage: 0,

--- a/pages/collection/collection.js
+++ b/pages/collection/collection.js
@@ -11,7 +11,19 @@ Page({
   refreshI18n: function () {
     this.setData({
       t: {
-        navTitle: i18n.t('collectionPage.navTitle')
+        navTitle: i18n.t('collectionPage.navTitle'),
+        myLoans: i18n.t('collectionPage.myLoans'),
+        myLoansDesc: i18n.t('collectionPage.myLoansDesc'),
+        bookNameLabel: i18n.t('collectionPage.bookNameLabel'),
+        bookNamePlaceholder: i18n.t('collectionPage.bookNamePlaceholder'),
+        bookNameValidation: i18n.t('collectionPage.bookNameValidation'),
+        queryButton: i18n.t('collectionPage.queryButton'),
+        noBooks: i18n.t('collectionPage.noBooks'),
+        queryResult: i18n.t('collectionPage.queryResult'),
+        loadMore: i18n.t('collectionPage.loadMore'),
+        noMoreBooks: i18n.t('collectionPage.noMoreBooks'),
+        loadingData: i18n.t('collectionPage.loadingData'),
+        shareTitle: i18n.t('collectionPage.shareTitle')
       }
     })
     wx.setNavigationBarTitle({ title: this.data.t.navTitle })
@@ -31,7 +43,7 @@ Page({
   formSubmit: function(e) {
     const keyword = e.detail.value.keyword
     if (!keyword) {
-      pageUtils.showTopTips(this, '请填写要查询的书名')
+      pageUtils.showTopTips(this, i18n.t('collectionPage.bookNameValidation'))
       return
     }
 
@@ -51,7 +63,7 @@ Page({
       }
 
       if (!result.collectionList || result.collectionList.length === 0) {
-        pageUtils.showTopTips(this, '没有找到对应的图书信息')
+        pageUtils.showTopTips(this, i18n.t('collectionPage.noBooks'))
         return
       }
 
@@ -68,11 +80,11 @@ Page({
 
   loadMore: function() {
     if (!this.data.keyword || this.data.currentPage >= this.data.sumPage) {
-      pageUtils.showTopTips(this, '没有更多图书信息')
+      pageUtils.showTopTips(this, i18n.t('collectionPage.noMoreBooks'))
       return
     }
 
-    wx.showLoading({ title: '数据加载中', mask: true })
+    wx.showLoading({ title: i18n.t('collectionPage.loadingData'), mask: true })
     const nextPage = this.data.currentPage + 1
 
     libraryApi.queryCollection(this.data.keyword, nextPage).then((result) => {
@@ -83,7 +95,7 @@ Page({
       }
 
       if (!result.collectionList || result.collectionList.length === 0) {
-        pageUtils.showTopTips(this, '没有更多图书信息')
+        pageUtils.showTopTips(this, i18n.t('collectionPage.noMoreBooks'))
         return
       }
 
@@ -100,7 +112,7 @@ Page({
 
   onShareAppMessage: function() {
     return {
-      title: '图书馆',
+      title: i18n.t('collectionPage.shareTitle'),
       path: '/pages/collection/collection'
     }
   }

--- a/pages/collection/collection.wxml
+++ b/pages/collection/collection.wxml
@@ -4,8 +4,8 @@
 
     <view class="module_shortcuts">
       <navigator url="/pages/book/book" class="shortcut_card" hover-class="shortcut_card_active">
-        <view class="shortcut_title">我的借阅</view>
-        <view class="shortcut_desc">查询借阅记录并完成续借</view>
+        <view class="shortcut_title">{{t.myLoans}}</view>
+        <view class="shortcut_desc">{{t.myLoansDesc}}</view>
       </navigator>
     </view>
 
@@ -19,17 +19,17 @@
           <view class="weui-cells weui-cells_after-title">
             <view class="weui-cell weui-cell_input weui-cell_vcode">
               <view class="weui-cell__hd">
-                <view class="weui-label">书名</view>
+                <view class="weui-label">{{t.bookNameLabel}}</view>
               </view>
               <view class="weui-cell__bd">
-                <input name="keyword" class="weui-input" maxlength='50' type="text" placeholder="请输入图书信息" />
+                <input name="keyword" class="weui-input" maxlength='50' type="text" placeholder="{{t.bookNamePlaceholder}}" />
               </view>
             </view>
           </view>
         </view>
 
         <view class="weui-btn-area">
-          <button class="weui-btn" disabled="{{loading}}" type="primary" formType="submit">查询</button>
+          <button class="weui-btn" disabled="{{loading}}" type="primary" formType="submit">{{t.queryButton}}</button>
         </view>
 
       </form>
@@ -39,7 +39,7 @@
   </view>
 
   <view block class="container" wx:if="{{list.length!=0}}">
-    <view class="weui-cells__title">查询结果</view>
+    <view class="weui-cells__title">{{t.queryResult}}</view>
     <view class="weui-cells weui-cells_after-title">
       <block wx:for="{{list}}" wx:for-item="i" wx:key="collectionList">
         <navigator url="../collectionDetail/collectionDetail?bookname={{i.bookname}}&{{i.detailURL}}" class="weui-cell weui-cell_access" hover-class="weui-cell_active">
@@ -48,8 +48,8 @@
         </navigator>
       </block>
     </view>
-    <text wx:if="{{currentPage<sumPage}}" class="loadmore" bindtap="loadMore">点击加载更多信息</text>
-    <text wx:if="{{currentPage>=sumPage}}" disable="true" class="loadmore">没有更多图书信息</text>
+    <text wx:if="{{currentPage<sumPage}}" class="loadmore" bindtap="loadMore">{{t.loadMore}}</text>
+    <text wx:if="{{currentPage>=sumPage}}" disable="true" class="loadmore">{{t.noMoreBooks}}</text>
   </view>
 
 </view>

--- a/pages/data/data.js
+++ b/pages/data/data.js
@@ -1,7 +1,21 @@
 var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
+
 Page({
   onShow: function () {
     themeUtil.applyTheme(this)
+    this.refreshI18n()
+  },
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        navTitle: i18n.t('dataPage.navTitle')
+      }
+    })
+    wx.setNavigationBarTitle({ title: this.data.t.navTitle })
+  },
+  data: {
+    t: {}
   },
   onShareAppMessage: function() {
     return {

--- a/pages/electricity/electricity.js
+++ b/pages/electricity/electricity.js
@@ -1,6 +1,7 @@
 const dataApi = require('../../services/apis/data.js')
 const pageUtils = require('../../utils/page.js')
 var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
 
 function buildYearOptions() {
   const currentYear = new Date().getFullYear()
@@ -14,9 +15,19 @@ function buildYearOptions() {
 Page({
   onShow: function () {
     themeUtil.applyTheme(this)
+    this.refreshI18n()
+  },
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        navTitle: i18n.t('electricityPage.navTitle')
+      }
+    })
+    wx.setNavigationBarTitle({ title: this.data.t.navTitle })
   },
   data: {
     themeClass: '',
+    t: {},
     yearOptions: buildYearOptions(),
     yearIndex: 0,
     name: '',

--- a/pages/evaluate/evaluate.js
+++ b/pages/evaluate/evaluate.js
@@ -12,7 +12,14 @@ Page({
   refreshI18n: function () {
     this.setData({
       t: {
-        navTitle: i18n.t('evaluatePage.navTitle')
+        navTitle: i18n.t('evaluatePage.navTitle'),
+        autoSubmitTitle: i18n.t('evaluatePage.autoSubmitTitle'),
+        autoSubmitLabel: i18n.t('evaluatePage.autoSubmitLabel'),
+        submitButton: i18n.t('evaluatePage.submitButton'),
+        successTitle: i18n.t('evaluatePage.successTitle'),
+        successWithSubmit: i18n.t('evaluatePage.successWithSubmit'),
+        successWithoutSubmit: i18n.t('evaluatePage.successWithoutSubmit'),
+        shareTitle: i18n.t('evaluatePage.shareTitle')
       }
     })
     wx.setNavigationBarTitle({ title: this.data.t.navTitle })
@@ -31,9 +38,9 @@ Page({
     }).then((result) => {
       if (result.success) {
         if (this.data.checked) {
-          utils.showModal('一键评教成功', '一键评教成功，评教信息已提交')
+          utils.showModal(i18n.t('evaluatePage.successTitle'), i18n.t('evaluatePage.successWithSubmit'))
         } else {
-          utils.showModal('一键评教成功', '一键评教成功，请登录教务系统进行最终确认')
+          utils.showModal(i18n.t('evaluatePage.successTitle'), i18n.t('evaluatePage.successWithoutSubmit'))
         }
       } else {
         pageUtils.showTopTips(this, result.message)
@@ -49,7 +56,7 @@ Page({
 
   onShareAppMessage: function() {
     return {
-      title: '教学评价',
+      title: i18n.t('evaluatePage.shareTitle'),
       path: '/pages/evaluate/evaluate'
     }
   }

--- a/pages/evaluate/evaluate.js
+++ b/pages/evaluate/evaluate.js
@@ -2,13 +2,24 @@ const utils = require('../../utils/util.js')
 const campusApi = require('../../services/apis/campus.js')
 const pageUtils = require('../../utils/page.js')
 var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
 
 Page({
   onShow: function () {
     themeUtil.applyTheme(this)
+    this.refreshI18n()
+  },
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        navTitle: i18n.t('evaluatePage.navTitle')
+      }
+    })
+    wx.setNavigationBarTitle({ title: this.data.t.navTitle })
   },
   data: {
     themeClass: '',
+    t: {},
     checked: false,
     loading: false,
     errorMessage: null

--- a/pages/evaluate/evaluate.wxml
+++ b/pages/evaluate/evaluate.wxml
@@ -4,10 +4,10 @@
 
   <form catchsubmit="formSubmit">
 
-    <view class="weui-cells__title">自动提交</view>
+    <view class="weui-cells__title">{{t.autoSubmitTitle}}</view>
     <view class="weui-cells weui-cells_after-title">
       <view class="weui-cell weui-cell_switch">
-        <view class="weui-cell__bd">直接提交评教信息</view>
+        <view class="weui-cell__bd">{{t.autoSubmitLabel}}</view>
         <view class="weui-cell__ft">
           <switch checked="{{checked}}" bindchange="changeSwitch" />
         </view>
@@ -15,7 +15,7 @@
     </view>
 
     <view class="btn-area">
-      <button type="primary" disabled="{{loading}}" formType="submit">提交</button>
+      <button type="primary" disabled="{{loading}}" formType="submit">{{t.submitButton}}</button>
     </view>
 
   </form>

--- a/pages/graduateExam/graduateExam.js
+++ b/pages/graduateExam/graduateExam.js
@@ -1,13 +1,24 @@
 const infoApi = require('../../services/apis/info.js')
 const pageUtils = require('../../utils/page.js')
 var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
 
 Page({
   onShow: function () {
     themeUtil.applyTheme(this)
+    this.refreshI18n()
+  },
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        navTitle: i18n.t('graduateExamPage.navTitle')
+      }
+    })
+    wx.setNavigationBarTitle({ title: this.data.t.navTitle })
   },
   data: {
     themeClass: '',
+    t: {},
     name: '',
     examNumber: '',
     idNumber: '',

--- a/pages/graduateExam/graduateExam.js
+++ b/pages/graduateExam/graduateExam.js
@@ -11,7 +11,27 @@ Page({
   refreshI18n: function () {
     this.setData({
       t: {
-        navTitle: i18n.t('graduateExamPage.navTitle')
+        navTitle: i18n.t('graduateExamPage.navTitle'),
+        queryInfo: i18n.t('graduateExamPage.queryInfo'),
+        nameLabel: i18n.t('graduateExamPage.nameLabel'),
+        namePlaceholder: i18n.t('graduateExamPage.namePlaceholder'),
+        examNumberLabel: i18n.t('graduateExamPage.examNumberLabel'),
+        examNumberPlaceholder: i18n.t('graduateExamPage.examNumberPlaceholder'),
+        idNumberLabel: i18n.t('graduateExamPage.idNumberLabel'),
+        idNumberPlaceholder: i18n.t('graduateExamPage.idNumberPlaceholder'),
+        queryButton: i18n.t('graduateExamPage.queryButton'),
+        fillAllFields: i18n.t('graduateExamPage.fillAllFields'),
+        resultTitle: i18n.t('graduateExamPage.resultTitle'),
+        resultName: i18n.t('graduateExamPage.resultName'),
+        signUpNumber: i18n.t('graduateExamPage.signUpNumber'),
+        resultExamNumber: i18n.t('graduateExamPage.resultExamNumber'),
+        totalScore: i18n.t('graduateExamPage.totalScore'),
+        firstScore: i18n.t('graduateExamPage.firstScore'),
+        secondScore: i18n.t('graduateExamPage.secondScore'),
+        thirdScore: i18n.t('graduateExamPage.thirdScore'),
+        fourthScore: i18n.t('graduateExamPage.fourthScore'),
+        reQuery: i18n.t('graduateExamPage.reQuery'),
+        shareTitle: i18n.t('graduateExamPage.shareTitle')
       }
     })
     wx.setNavigationBarTitle({ title: this.data.t.navTitle })
@@ -42,7 +62,7 @@ Page({
     }
 
     if (!payload.name || !payload.examNumber || !payload.idNumber) {
-      pageUtils.showTopTips(this, '请完整填写考研查询信息')
+      pageUtils.showTopTips(this, i18n.t('graduateExamPage.fillAllFields'))
       return
     }
 
@@ -65,7 +85,7 @@ Page({
 
   onShareAppMessage: function() {
     return {
-      title: '考研查询',
+      title: i18n.t('graduateExamPage.shareTitle'),
       path: '/pages/graduateExam/graduateExam'
     }
   }

--- a/pages/graduateExam/graduateExam.wxml
+++ b/pages/graduateExam/graduateExam.wxml
@@ -2,78 +2,78 @@
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="container" wx:if="{{!result}}">
-    <view class="weui-cells__title">查询信息</view>
+    <view class="weui-cells__title">{{t.queryInfo}}</view>
     <view class="weui-cells weui-cells_after-title">
       <view class="weui-cell weui-cell_input">
         <view class="weui-cell__hd">
-          <view class="weui-label">姓名</view>
+          <view class="weui-label">{{t.nameLabel}}</view>
         </view>
         <view class="weui-cell__bd">
-          <input value="{{name}}" data-field="name" bindinput="setFieldValue" class="weui-input" placeholder="请输入姓名" />
+          <input value="{{name}}" data-field="name" bindinput="setFieldValue" class="weui-input" placeholder="{{t.namePlaceholder}}" />
         </view>
       </view>
       <view class="weui-cell weui-cell_input">
         <view class="weui-cell__hd">
-          <view class="weui-label">考号</view>
+          <view class="weui-label">{{t.examNumberLabel}}</view>
         </view>
         <view class="weui-cell__bd">
-          <input value="{{examNumber}}" data-field="examNumber" bindinput="setFieldValue" class="weui-input" placeholder="请输入准考证号" />
+          <input value="{{examNumber}}" data-field="examNumber" bindinput="setFieldValue" class="weui-input" placeholder="{{t.examNumberPlaceholder}}" />
         </view>
       </view>
       <view class="weui-cell weui-cell_input">
         <view class="weui-cell__hd">
-          <view class="weui-label">证件号</view>
+          <view class="weui-label">{{t.idNumberLabel}}</view>
         </view>
         <view class="weui-cell__bd">
-          <input value="{{idNumber}}" data-field="idNumber" bindinput="setFieldValue" class="weui-input" placeholder="请输入证件号" />
+          <input value="{{idNumber}}" data-field="idNumber" bindinput="setFieldValue" class="weui-input" placeholder="{{t.idNumberPlaceholder}}" />
         </view>
       </view>
     </view>
 
     <view class="btn-area">
-      <button type="primary" disabled="{{loading}}" bindtap="submitQuery">查询</button>
+      <button type="primary" disabled="{{loading}}" bindtap="submitQuery">{{t.queryButton}}</button>
     </view>
   </view>
 
   <view class="container" wx:if="{{result}}">
-    <view class="weui-cells__title">考研成绩</view>
+    <view class="weui-cells__title">{{t.resultTitle}}</view>
     <view class="weui-cells weui-cells_after-title">
       <view class="weui-cell">
-        <view class="weui-cell__bd">姓名</view>
+        <view class="weui-cell__bd">{{t.resultName}}</view>
         <view class="weui-cell__ft">{{result.name}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">报名号</view>
+        <view class="weui-cell__bd">{{t.signUpNumber}}</view>
         <view class="weui-cell__ft">{{result.signUpNumber}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">准考证号</view>
+        <view class="weui-cell__bd">{{t.resultExamNumber}}</view>
         <view class="weui-cell__ft">{{result.examNumber}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">总分</view>
+        <view class="weui-cell__bd">{{t.totalScore}}</view>
         <view class="weui-cell__ft">{{result.totalScore}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">科目一</view>
+        <view class="weui-cell__bd">{{t.firstScore}}</view>
         <view class="weui-cell__ft">{{result.firstScore}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">科目二</view>
+        <view class="weui-cell__bd">{{t.secondScore}}</view>
         <view class="weui-cell__ft">{{result.secondScore}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">科目三</view>
+        <view class="weui-cell__bd">{{t.thirdScore}}</view>
         <view class="weui-cell__ft">{{result.thirdScore}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">科目四</view>
+        <view class="weui-cell__bd">{{t.fourthScore}}</view>
         <view class="weui-cell__ft">{{result.fourthScore}}</view>
       </view>
     </view>
 
     <view class="btn-area">
-      <button type="primary" bindtap="resetQuery">重新查询</button>
+      <button type="primary" bindtap="resetQuery">{{t.reQuery}}</button>
     </view>
   </view>
 </view>

--- a/pages/schedule/schedule.js
+++ b/pages/schedule/schedule.js
@@ -23,7 +23,7 @@ Page({
   refreshI18n: function () {
     var tabs = i18n.t('schedule.tabs')
     if (!Array.isArray(tabs)) {
-      tabs = ['周一', '周二', '周三', '周四', '周五', '周六', '周日']
+      tabs = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
     }
     this.setData({
       tabs: tabs,

--- a/pages/yellowPage/yellowPage.js
+++ b/pages/yellowPage/yellowPage.js
@@ -1,6 +1,7 @@
 const dataApi = require('../../services/apis/data.js')
 const pageUtils = require('../../utils/page.js')
 var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
 
 function groupYellowPage(result) {
   const typeList = result.type || []
@@ -22,9 +23,19 @@ function groupYellowPage(result) {
 Page({
   onShow: function () {
     themeUtil.applyTheme(this)
+    this.refreshI18n()
+  },
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        navTitle: i18n.t('yellowPagePage.navTitle')
+      }
+    })
+    wx.setNavigationBarTitle({ title: this.data.t.navTitle })
   },
   data: {
     themeClass: '',
+    t: {},
     loading: false,
     groupedYellowPages: [],
     errorMessage: null


### PR DESCRIPTION
## Summary
- 9 pages: add dynamic wx.setNavigationBarTitle for bill/book/graduateExam/data/cardLost/electricity/collection/yellowPage/evaluate
- 5 pages: full body i18n for bill/cardLost/collection/evaluate/graduateExam
- Schedule tabs: change Chinese fallback to English abbreviations

## Test plan
- [x] `node --test` — 23 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)