### PR TITLE
refactor: add WeChat community module registry (marketplace + lostandfound)

### DIFF
--- a/pages/communityCenter/communityCenter.js
+++ b/pages/communityCenter/communityCenter.js
@@ -1,24 +1,18 @@
 const { getCommunityModule, getCommunityPageTitle } = require('../../constants/community.js')
 const communityApi = require('../../services/apis/community.js')
+const { getModuleHandler } = require('../../services/community/registry.js')
 const userApi = require('../../services/apis/user.js')
 const pageUtils = require('../../utils/page.js')
 const i18n = require('../../utils/i18n.js')
 var themeUtil = require('../../utils/theme')
 
 function buildTabs(moduleId) {
+  var handler = getModuleHandler(moduleId)
+  if (handler && handler.buildCenterTabs) {
+    return handler.buildCenterTabs()
+  }
+
   switch (moduleId) {
-    case 'ershou':
-      return [
-        { key: 'doing', label: i18n.t('community.center.tabSelling') },
-        { key: 'sold', label: i18n.t('community.center.tabSold') },
-        { key: 'off', label: i18n.t('community.center.tabOffShelf') }
-      ]
-    case 'lostandfound':
-      return [
-        { key: 'lost', label: i18n.t('community.center.tabLost') },
-        { key: 'found', label: i18n.t('community.center.tabFound') },
-        { key: 'didfound', label: i18n.t('community.center.tabRecovered') }
-      ]
     case 'delivery':
       return [
         { key: 'published', label: i18n.t('community.center.tabMyPublished') },
@@ -83,92 +77,12 @@ Page({
   },
 
   normalizeCenterData: function(moduleId, payload) {
+    var handler = getModuleHandler(moduleId)
+    if (handler && handler.normalizeCenterData) {
+      return handler.normalizeCenterData(payload, normalizeStandardItem)
+    }
+
     switch (moduleId) {
-      case 'ershou':
-        return {
-          doing: (payload.doing || []).map(function(item) {
-            return normalizeStandardItem(item, {
-              id: item.id,
-              title: item.name,
-              subtitle: item.publishTime,
-              summary: item.location,
-              cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/ershou.png',
-              priceText: Number(item.price || 0).toFixed(2),
-              actions: [
-                { id: 'edit', label: i18n.t('community.center.actionEdit') },
-                { id: 'state:0', label: i18n.t('community.center.actionOffShelf') },
-                { id: 'state:2', label: i18n.t('community.center.actionSold') }
-              ]
-            })
-          }),
-          sold: (payload.sold || []).map(function(item) {
-            return normalizeStandardItem(item, {
-              id: item.id,
-              title: item.name,
-              subtitle: item.publishTime,
-              summary: item.location,
-              cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/ershou.png',
-              priceText: Number(item.price || 0).toFixed(2),
-              actions: [],
-              canOpenDetail: false
-            })
-          }),
-          off: (payload.off || []).map(function(item) {
-            return normalizeStandardItem(item, {
-              id: item.id,
-              title: item.name,
-              subtitle: item.publishTime,
-              summary: item.location,
-              cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/ershou.png',
-              priceText: Number(item.price || 0).toFixed(2),
-              actions: [
-                { id: 'edit', label: i18n.t('community.center.actionEdit') },
-                { id: 'state:1', label: i18n.t('community.center.actionRelist') }
-              ],
-              canOpenDetail: false
-            })
-          })
-        }
-      case 'lostandfound':
-        return {
-          lost: (payload.lost || []).map(function(item) {
-            return normalizeStandardItem(item, {
-              id: item.id,
-              title: item.name,
-              subtitle: item.publishTime,
-              summary: item.location,
-              cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/lostandfound.png',
-              actions: [
-                { id: 'edit', label: i18n.t('community.center.actionEdit') },
-                { id: 'didfound', label: i18n.t('community.center.actionConfirmFound') }
-              ]
-            })
-          }),
-          found: (payload.found || []).map(function(item) {
-            return normalizeStandardItem(item, {
-              id: item.id,
-              title: item.name,
-              subtitle: item.publishTime,
-              summary: item.location,
-              cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/lostandfound.png',
-              actions: [
-                { id: 'edit', label: i18n.t('community.center.actionEdit') },
-                { id: 'didfound', label: i18n.t('community.center.actionConfirmFound') }
-              ]
-            })
-          }),
-          didfound: (payload.didfound || []).map(function(item) {
-            return normalizeStandardItem(item, {
-              id: item.id,
-              title: item.name,
-              subtitle: item.publishTime,
-              summary: item.location,
-              cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/lostandfound.png',
-              actions: [],
-              canOpenDetail: false
-            })
-          })
-        }
       case 'secret':
         return {
           default: (payload || []).map(function(item) {
@@ -295,7 +209,10 @@ Page({
   },
 
   loadSummaryProfile: function() {
-    if (['ershou', 'lostandfound'].indexOf(this.data.moduleId) === -1) {
+    var handler = getModuleHandler(this.data.moduleId)
+    var shouldShowProfile = handler ? !!handler.showSummaryProfile : (['ershou', 'lostandfound'].indexOf(this.data.moduleId) !== -1)
+
+    if (!shouldShowProfile) {
       this.setData({
         summaryProfile: null
       })

--- a/pages/communityList/communityList.js
+++ b/pages/communityList/communityList.js
@@ -10,6 +10,7 @@ const {
 } = require('../../constants/community.js')
 const { fetchProfileOptions } = require('../../constants/profile.js')
 const communityApi = require('../../services/apis/community.js')
+const { getModuleHandler } = require('../../services/community/registry.js')
 const pageUtils = require('../../utils/page.js')
 const i18n = require('../../utils/i18n.js')
 var themeUtil = require('../../utils/theme')
@@ -36,33 +37,14 @@ function formatSecretPublishText(publishTime, timer) {
 }
 
 function normalizeItem(moduleId, item) {
+  var handler = getModuleHandler(moduleId)
+  if (handler && handler.normalizeItem) {
+    return handler.normalizeItem(item)
+  }
+
   const rawItem = item || {}
 
   switch (moduleId) {
-    case 'ershou':
-      return {
-        id: rawItem.id,
-        title: rawItem.name || i18n.t('community.list.unnamedProduct'),
-        summary: rawItem.description || '',
-        cover: rawItem.pictureURL && rawItem.pictureURL.length ? rawItem.pictureURL[0] : '/image/ershou.png',
-        priceText: formatPrice(rawItem.price),
-        badgeText: findLabel(getSecondhandCategoryOptions(), rawItem.type, i18n.t('community.list.secondhand')),
-        metaText: rawItem.location || '',
-        timeText: rawItem.publishTime || '',
-        raw: rawItem
-      }
-    case 'lostandfound':
-      return {
-        id: rawItem.id,
-        title: rawItem.name || i18n.t('community.list.unnamedItem'),
-        summary: rawItem.description || '',
-        cover: rawItem.pictureURL && rawItem.pictureURL.length ? rawItem.pictureURL[0] : '/image/lostandfound.png',
-        badgeText: Number(rawItem.lostType) === 0 ? i18n.t('community.list.lost') : i18n.t('community.list.found'),
-        subBadgeText: findLabel(getLostFoundItemDictionaryOptions(), rawItem.itemType, i18n.t('community.category.other')),
-        metaText: rawItem.location || '',
-        timeText: rawItem.publishTime || '',
-        raw: rawItem
-      }
     case 'secret':
       return {
         id: rawItem.id,
@@ -156,11 +138,12 @@ Page({
   },
 
   buildTabs: function(moduleId) {
+    var handler = getModuleHandler(moduleId)
+    if (handler && handler.buildListTabs) {
+      return handler.buildListTabs()
+    }
+
     switch (moduleId) {
-      case 'ershou':
-        return getSecondhandCategoryOptions()
-      case 'lostandfound':
-        return getLostFoundModeDictionaryOptions()
       case 'delivery':
         return getDeliveryStatusOptions()
       case 'dating':
@@ -185,12 +168,9 @@ Page({
       keyword: this.data.searchKeyword
     }
 
-    if (moduleId === 'ershou') {
-      options.type = activeTab && Number(activeTab.value) >= 0 ? Number(activeTab.value) : null
-    }
-
-    if (moduleId === 'lostandfound') {
-      options.mode = activeTab ? Number(activeTab.value) : 0
+    var handler = getModuleHandler(moduleId)
+    if (handler && handler.buildFeedOptions) {
+      return handler.buildFeedOptions(options, activeTab)
     }
 
     if (moduleId === 'dating') {

--- a/services/apis/community.js
+++ b/services/apis/community.js
@@ -1,6 +1,7 @@
 const endpoints = require('../endpoints.js')
 const { request } = require('../request.js')
 const { encodeForm } = require('../../utils/form.js')
+const { getModuleHandler } = require('../community/registry.js')
 
 function requestForm(options) {
   return request(Object.assign({}, options, {
@@ -9,48 +10,17 @@ function requestForm(options) {
 }
 
 function getFeed(moduleId, options) {
+  var handler = getModuleHandler(moduleId)
+  if (handler && handler.getFeed) {
+    return handler.getFeed(options)
+  }
+
   const config = options || {}
   const start = Number(config.start || 0)
   const size = Number(config.size || 10)
   const keyword = String(config.keyword || '').trim()
 
   switch (moduleId) {
-    case 'marketplace':
-      if (keyword) {
-        return request({
-          url: endpoints.community.secondhand.keyword(encodeURIComponent(keyword), start),
-          method: 'GET',
-          authRequired: true
-        })
-      }
-      if (typeof config.type === 'number' && config.type >= 0) {
-        return request({
-          url: endpoints.community.secondhand.type(config.type, start),
-          method: 'GET',
-          authRequired: true
-        })
-      }
-      return request({
-        url: endpoints.community.secondhand.list(start),
-        method: 'GET',
-        authRequired: true
-      })
-    case 'lostandfound':
-      if (keyword) {
-        return requestForm({
-          url: endpoints.community.lostAndFound.search(config.mode || 0, start),
-          method: 'POST',
-          authRequired: true,
-          data: encodeForm({ keyword: keyword })
-        })
-      }
-      return request({
-        url: Number(config.mode || 0) === 0
-          ? endpoints.community.lostAndFound.lost(start)
-          : endpoints.community.lostAndFound.found(start),
-        method: 'GET',
-        authRequired: true
-      })
     case 'secret':
       return request({
         url: endpoints.community.secret.list(start, size),
@@ -97,19 +67,12 @@ function getFeed(moduleId, options) {
 }
 
 function getDetail(moduleId, id) {
+  var handler = getModuleHandler(moduleId)
+  if (handler && handler.getDetail) {
+    return handler.getDetail(id)
+  }
+
   switch (moduleId) {
-    case 'marketplace':
-      return request({
-        url: endpoints.community.secondhand.detail(id),
-        method: 'GET',
-        authRequired: true
-      })
-    case 'lostandfound':
-      return request({
-        url: endpoints.community.lostAndFound.detail(id),
-        method: 'GET',
-        authRequired: true
-      })
     case 'secret':
       return request({
         url: endpoints.community.secret.detail(id),
@@ -180,23 +143,16 @@ function getComments(moduleId, id) {
 }
 
 function getCenter(moduleId, options) {
+  var handler = getModuleHandler(moduleId)
+  if (handler && handler.getCenter) {
+    return handler.getCenter(options)
+  }
+
   const config = options || {}
   const start = Number(config.start || 0)
   const size = Number(config.size || 10)
 
   switch (moduleId) {
-    case 'marketplace':
-      return request({
-        url: endpoints.community.secondhand.profile,
-        method: 'GET',
-        authRequired: true
-      })
-    case 'lostandfound':
-      return request({
-        url: endpoints.community.lostAndFound.profile,
-        method: 'GET',
-        authRequired: true
-      })
     case 'secret':
       return request({
         url: endpoints.community.secret.profile,
@@ -262,21 +218,12 @@ function getCenter(moduleId, options) {
 }
 
 function publish(moduleId, payload) {
+  var handler = getModuleHandler(moduleId)
+  if (handler && handler.publish) {
+    return handler.publish(payload)
+  }
+
   switch (moduleId) {
-    case 'marketplace':
-      return requestForm({
-        url: endpoints.community.secondhand.publish,
-        method: 'POST',
-        authRequired: true,
-        data: encodeForm(payload)
-      })
-    case 'lostandfound':
-      return requestForm({
-        url: endpoints.community.lostAndFound.publish,
-        method: 'POST',
-        authRequired: true,
-        data: encodeForm(payload)
-      })
     case 'secret':
       return requestForm({
         url: endpoints.community.secret.publish,

--- a/services/community/module-handlers/lostandfound.js
+++ b/services/community/module-handlers/lostandfound.js
@@ -1,0 +1,155 @@
+const endpoints = require('../../endpoints.js')
+const { request } = require('../../request.js')
+const { encodeForm } = require('../../../utils/form.js')
+const i18n = require('../../../utils/i18n.js')
+const {
+  getLostFoundModeDictionaryOptions,
+  getLostFoundItemDictionaryOptions
+} = require('../../../constants/community.js')
+
+function findLabel(options, value, fallback) {
+  const item = (options || []).filter(function(optionItem) {
+    return Number(optionItem.value) === Number(value) || Number(optionItem.feedValue) === Number(value)
+  })[0]
+  return item ? item.label : (fallback || '')
+}
+
+module.exports = {
+  // --- Feed ---
+  getFeed: function(options) {
+    var config = options || {}
+    var start = Number(config.start || 0)
+    var keyword = String(config.keyword || '').trim()
+
+    if (keyword) {
+      return request(Object.assign({}, {
+        url: endpoints.community.lostAndFound.search(config.mode || 0, start),
+        method: 'POST',
+        authRequired: true,
+        data: encodeForm({ keyword: keyword }),
+        contentType: 'application/x-www-form-urlencoded'
+      }))
+    }
+    return request({
+      url: Number(config.mode || 0) === 0
+        ? endpoints.community.lostAndFound.lost(start)
+        : endpoints.community.lostAndFound.found(start),
+      method: 'GET',
+      authRequired: true
+    })
+  },
+
+  // --- Detail ---
+  getDetail: function(id) {
+    return request({
+      url: endpoints.community.lostAndFound.detail(id),
+      method: 'GET',
+      authRequired: true
+    })
+  },
+
+  // --- Center ---
+  getCenter: function() {
+    return request({
+      url: endpoints.community.lostAndFound.profile,
+      method: 'GET',
+      authRequired: true
+    })
+  },
+
+  // --- Publish ---
+  publish: function(payload) {
+    return request(Object.assign({}, {
+      url: endpoints.community.lostAndFound.publish,
+      method: 'POST',
+      authRequired: true,
+      data: encodeForm(payload),
+      contentType: 'application/x-www-form-urlencoded'
+    }))
+  },
+
+  // --- List page: tabs ---
+  buildListTabs: function() {
+    return getLostFoundModeDictionaryOptions()
+  },
+
+  // --- List page: normalize ---
+  normalizeItem: function(item) {
+    var rawItem = item || {}
+    return {
+      id: rawItem.id,
+      title: rawItem.name || i18n.t('community.list.unnamedItem'),
+      summary: rawItem.description || '',
+      cover: rawItem.pictureURL && rawItem.pictureURL.length ? rawItem.pictureURL[0] : '/image/lostandfound.png',
+      badgeText: Number(rawItem.lostType) === 0 ? i18n.t('community.list.lost') : i18n.t('community.list.found'),
+      subBadgeText: findLabel(getLostFoundItemDictionaryOptions(), rawItem.itemType, i18n.t('community.category.other')),
+      metaText: rawItem.location || '',
+      timeText: rawItem.publishTime || '',
+      raw: rawItem
+    }
+  },
+
+  // --- List page: build feed options ---
+  buildFeedOptions: function(baseOptions, activeTab) {
+    var options = Object.assign({}, baseOptions)
+    options.mode = activeTab ? Number(activeTab.value) : 0
+    return options
+  },
+
+  // --- Center page: tabs ---
+  buildCenterTabs: function() {
+    return [
+      { key: 'lost', label: i18n.t('community.center.tabLost') },
+      { key: 'found', label: i18n.t('community.center.tabFound') },
+      { key: 'didfound', label: i18n.t('community.center.tabRecovered') }
+    ]
+  },
+
+  // --- Center page: normalize ---
+  normalizeCenterData: function(payload, normalizeStandardItem) {
+    return {
+      lost: (payload.lost || []).map(function(item) {
+        return normalizeStandardItem(item, {
+          id: item.id,
+          title: item.name,
+          subtitle: item.publishTime,
+          summary: item.location,
+          cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/lostandfound.png',
+          actions: [
+            { id: 'edit', label: i18n.t('community.center.actionEdit') },
+            { id: 'didfound', label: i18n.t('community.center.actionConfirmFound') }
+          ]
+        })
+      }),
+      found: (payload.found || []).map(function(item) {
+        return normalizeStandardItem(item, {
+          id: item.id,
+          title: item.name,
+          subtitle: item.publishTime,
+          summary: item.location,
+          cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/lostandfound.png',
+          actions: [
+            { id: 'edit', label: i18n.t('community.center.actionEdit') },
+            { id: 'didfound', label: i18n.t('community.center.actionConfirmFound') }
+          ]
+        })
+      }),
+      didfound: (payload.didfound || []).map(function(item) {
+        return normalizeStandardItem(item, {
+          id: item.id,
+          title: item.name,
+          subtitle: item.publishTime,
+          summary: item.location,
+          cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/lostandfound.png',
+          actions: [],
+          canOpenDetail: false
+        })
+      })
+    }
+  },
+
+  // --- Center page: show summary profile ---
+  showSummaryProfile: true,
+
+  searchable: true
+}

--- a/services/community/module-handlers/marketplace.js
+++ b/services/community/module-handlers/marketplace.js
@@ -1,0 +1,167 @@
+const endpoints = require('../../endpoints.js')
+const { request } = require('../../request.js')
+const { encodeForm } = require('../../../utils/form.js')
+const i18n = require('../../../utils/i18n.js')
+const {
+  getSecondhandCategoryOptions
+} = require('../../../constants/community.js')
+
+function findLabel(options, value, fallback) {
+  const item = (options || []).filter(function(optionItem) {
+    return Number(optionItem.value) === Number(value) || Number(optionItem.feedValue) === Number(value)
+  })[0]
+  return item ? item.label : (fallback || '')
+}
+
+function formatPrice(value) {
+  const price = Number(value || 0)
+  return price ? price.toFixed(2) : '0.00'
+}
+
+module.exports = {
+  // --- Feed ---
+  getFeed: function(options) {
+    var config = options || {}
+    var start = Number(config.start || 0)
+    var keyword = String(config.keyword || '').trim()
+
+    if (keyword) {
+      return request({
+        url: endpoints.community.secondhand.keyword(encodeURIComponent(keyword), start),
+        method: 'GET',
+        authRequired: true
+      })
+    }
+    if (typeof config.type === 'number' && config.type >= 0) {
+      return request({
+        url: endpoints.community.secondhand.type(config.type, start),
+        method: 'GET',
+        authRequired: true
+      })
+    }
+    return request({
+      url: endpoints.community.secondhand.list(start),
+      method: 'GET',
+      authRequired: true
+    })
+  },
+
+  // --- Detail ---
+  getDetail: function(id) {
+    return request({
+      url: endpoints.community.secondhand.detail(id),
+      method: 'GET',
+      authRequired: true
+    })
+  },
+
+  // --- Center ---
+  getCenter: function() {
+    return request({
+      url: endpoints.community.secondhand.profile,
+      method: 'GET',
+      authRequired: true
+    })
+  },
+
+  // --- Publish ---
+  publish: function(payload) {
+    return request(Object.assign({}, {
+      url: endpoints.community.secondhand.publish,
+      method: 'POST',
+      authRequired: true,
+      data: encodeForm(payload),
+      contentType: 'application/x-www-form-urlencoded'
+    }))
+  },
+
+  // --- List page: tabs ---
+  buildListTabs: function() {
+    return getSecondhandCategoryOptions()
+  },
+
+  // --- List page: normalize ---
+  normalizeItem: function(item) {
+    var rawItem = item || {}
+    return {
+      id: rawItem.id,
+      title: rawItem.name || i18n.t('community.list.unnamedProduct'),
+      summary: rawItem.description || '',
+      cover: rawItem.pictureURL && rawItem.pictureURL.length ? rawItem.pictureURL[0] : '/image/ershou.png',
+      priceText: formatPrice(rawItem.price),
+      badgeText: findLabel(getSecondhandCategoryOptions(), rawItem.type, i18n.t('community.list.secondhand')),
+      metaText: rawItem.location || '',
+      timeText: rawItem.publishTime || '',
+      raw: rawItem
+    }
+  },
+
+  // --- List page: build feed options ---
+  buildFeedOptions: function(baseOptions, activeTab) {
+    var options = Object.assign({}, baseOptions)
+    options.type = activeTab && Number(activeTab.value) >= 0 ? Number(activeTab.value) : null
+    return options
+  },
+
+  // --- Center page: tabs ---
+  buildCenterTabs: function() {
+    return [
+      { key: 'doing', label: i18n.t('community.center.tabSelling') },
+      { key: 'sold', label: i18n.t('community.center.tabSold') },
+      { key: 'off', label: i18n.t('community.center.tabOffShelf') }
+    ]
+  },
+
+  // --- Center page: normalize ---
+  normalizeCenterData: function(payload, normalizeStandardItem) {
+    return {
+      doing: (payload.doing || []).map(function(item) {
+        return normalizeStandardItem(item, {
+          id: item.id,
+          title: item.name,
+          subtitle: item.publishTime,
+          summary: item.location,
+          cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/ershou.png',
+          priceText: Number(item.price || 0).toFixed(2),
+          actions: [
+            { id: 'edit', label: i18n.t('community.center.actionEdit') },
+            { id: 'state:0', label: i18n.t('community.center.actionOffShelf') },
+            { id: 'state:2', label: i18n.t('community.center.actionSold') }
+          ]
+        })
+      }),
+      sold: (payload.sold || []).map(function(item) {
+        return normalizeStandardItem(item, {
+          id: item.id,
+          title: item.name,
+          subtitle: item.publishTime,
+          summary: item.location,
+          cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/ershou.png',
+          priceText: Number(item.price || 0).toFixed(2),
+          actions: [],
+          canOpenDetail: false
+        })
+      }),
+      off: (payload.off || []).map(function(item) {
+        return normalizeStandardItem(item, {
+          id: item.id,
+          title: item.name,
+          subtitle: item.publishTime,
+          summary: item.location,
+          cover: item.pictureURL && item.pictureURL.length ? item.pictureURL[0] : '/image/ershou.png',
+          priceText: Number(item.price || 0).toFixed(2),
+          actions: [
+            { id: 'edit', label: i18n.t('community.center.actionEdit') },
+            { id: 'state:1', label: i18n.t('community.center.actionRelist') }
+          ],
+          canOpenDetail: false
+        })
+      })
+    }
+  },
+
+  // --- Center page: show summary profile ---
+  showSummaryProfile: true,
+
+  searchable: true
+}

--- a/services/community/registry.js
+++ b/services/community/registry.js
@@ -1,0 +1,17 @@
+var marketplaceHandler = require('./module-handlers/marketplace.js')
+var lostandfoundHandler = require('./module-handlers/lostandfound.js')
+
+var COMMUNITY_MODULES = {
+  marketplace: marketplaceHandler,
+  ershou: marketplaceHandler,       // legacy alias used by some pages
+  lostandfound: lostandfoundHandler
+}
+
+function getModuleHandler(moduleId) {
+  return COMMUNITY_MODULES[moduleId] || null
+}
+
+module.exports = {
+  COMMUNITY_MODULES: COMMUNITY_MODULES,
+  getModuleHandler: getModuleHandler
+}

--- a/tests/community-registry.test.js
+++ b/tests/community-registry.test.js
@@ -1,0 +1,136 @@
+const path = require('node:path')
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { clearModule, stubModule } = require('./helpers/module.js')
+
+const ROOT = path.resolve(__dirname, '..')
+
+// Stub i18n so handler modules can load without the full WeChat environment
+const I18N_MODULE = path.join(ROOT, 'utils/i18n.js')
+stubModule(I18N_MODULE, {
+  t: function(key) { return key },
+  tReplace: function(key) { return key }
+})
+
+// Stub request module
+const REQUEST_MODULE = path.join(ROOT, 'services/request.js')
+stubModule(REQUEST_MODULE, {
+  request: function() { return Promise.resolve({ success: true }) }
+})
+
+// Clear registry and handler caches so they pick up our stubs
+clearModule(path.join(ROOT, 'services/community/module-handlers/marketplace.js'))
+clearModule(path.join(ROOT, 'services/community/module-handlers/lostandfound.js'))
+clearModule(path.join(ROOT, 'services/community/registry.js'))
+
+const { getModuleHandler } = require(path.join(ROOT, 'services/community/registry.js'))
+
+test('marketplace handler has feedEndpoint, tabs, and normalizeItem', function() {
+  const handler = getModuleHandler('marketplace')
+
+  assert.ok(handler, 'marketplace handler should exist')
+  assert.equal(typeof handler.getFeed, 'function', 'should have getFeed')
+  assert.equal(typeof handler.buildListTabs, 'function', 'should have buildListTabs')
+  assert.equal(typeof handler.normalizeItem, 'function', 'should have normalizeItem')
+  assert.equal(typeof handler.getDetail, 'function', 'should have getDetail')
+  assert.equal(typeof handler.getCenter, 'function', 'should have getCenter')
+  assert.equal(typeof handler.publish, 'function', 'should have publish')
+  assert.equal(typeof handler.buildCenterTabs, 'function', 'should have buildCenterTabs')
+  assert.equal(typeof handler.normalizeCenterData, 'function', 'should have normalizeCenterData')
+  assert.equal(typeof handler.buildFeedOptions, 'function', 'should have buildFeedOptions')
+  assert.equal(handler.searchable, true, 'should be searchable')
+})
+
+test('lostandfound handler has feedEndpoint, tabs, and normalizeItem', function() {
+  const handler = getModuleHandler('lostandfound')
+
+  assert.ok(handler, 'lostandfound handler should exist')
+  assert.equal(typeof handler.getFeed, 'function', 'should have getFeed')
+  assert.equal(typeof handler.buildListTabs, 'function', 'should have buildListTabs')
+  assert.equal(typeof handler.normalizeItem, 'function', 'should have normalizeItem')
+  assert.equal(typeof handler.getDetail, 'function', 'should have getDetail')
+  assert.equal(typeof handler.getCenter, 'function', 'should have getCenter')
+  assert.equal(typeof handler.publish, 'function', 'should have publish')
+  assert.equal(typeof handler.buildCenterTabs, 'function', 'should have buildCenterTabs')
+  assert.equal(typeof handler.normalizeCenterData, 'function', 'should have normalizeCenterData')
+  assert.equal(typeof handler.buildFeedOptions, 'function', 'should have buildFeedOptions')
+  assert.equal(handler.searchable, true, 'should be searchable')
+})
+
+test('getModuleHandler returns null for unknown moduleId', function() {
+  assert.equal(getModuleHandler('nonexistent'), null)
+  assert.equal(getModuleHandler(''), null)
+  assert.equal(getModuleHandler(undefined), null)
+})
+
+test('ershou alias resolves to same handler as marketplace', function() {
+  const marketplace = getModuleHandler('marketplace')
+  const ershou = getModuleHandler('ershou')
+  assert.ok(marketplace, 'marketplace handler should exist')
+  assert.ok(ershou, 'ershou handler should exist')
+  assert.equal(marketplace, ershou, 'ershou should be the same handler as marketplace')
+})
+
+test('marketplace normalizeItem produces expected shape', function() {
+  const handler = getModuleHandler('marketplace')
+  const result = handler.normalizeItem({
+    id: 42,
+    name: 'Test Item',
+    description: 'A description',
+    pictureURL: ['/img/test.png'],
+    price: 19.99,
+    type: 1,
+    location: 'Campus A',
+    publishTime: '2025-01-01'
+  })
+
+  assert.equal(result.id, 42)
+  assert.equal(result.title, 'Test Item')
+  assert.equal(result.summary, 'A description')
+  assert.equal(result.cover, '/img/test.png')
+  assert.equal(result.priceText, '19.99')
+  assert.equal(result.metaText, 'Campus A')
+  assert.equal(result.timeText, '2025-01-01')
+  assert.ok(result.raw, 'should preserve raw item')
+})
+
+test('lostandfound normalizeItem produces expected shape', function() {
+  const handler = getModuleHandler('lostandfound')
+  const result = handler.normalizeItem({
+    id: 99,
+    name: 'Lost Phone',
+    description: 'Black phone',
+    pictureURL: ['/img/phone.png'],
+    lostType: 0,
+    itemType: 0,
+    location: 'Library',
+    publishTime: '2025-02-01'
+  })
+
+  assert.equal(result.id, 99)
+  assert.equal(result.title, 'Lost Phone')
+  assert.equal(result.summary, 'Black phone')
+  assert.equal(result.cover, '/img/phone.png')
+  assert.equal(result.metaText, 'Library')
+  assert.equal(result.timeText, '2025-02-01')
+  assert.ok(result.raw, 'should preserve raw item')
+})
+
+test('marketplace buildFeedOptions sets type from activeTab', function() {
+  const handler = getModuleHandler('marketplace')
+  const result = handler.buildFeedOptions(
+    { start: 0, size: 10, keyword: '' },
+    { value: 3 }
+  )
+  assert.equal(result.type, 3)
+})
+
+test('lostandfound buildFeedOptions sets mode from activeTab', function() {
+  const handler = getModuleHandler('lostandfound')
+  const result = handler.buildFeedOptions(
+    { start: 0, size: 10, keyword: '' },
+    { value: 1 }
+  )
+  assert.equal(result.mode, 1)
+})


### PR DESCRIPTION
## Summary
- Create `services/community/registry.js` with `getModuleHandler()` pattern
- Create module handlers for marketplace and lostandfound
- Migrate marketplace/lostandfound from switch blocks to registry in apis, communityList, communityCenter
- Add 8 registry-focused unit tests (31 total pass)
- Remaining modules stay on old switch for rollout phase

## Test plan
- [x] `node --test` — 31 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)