### PR TITLE
perf: lazy-load inbox interactions + skip duplicate photograph comments

### DIFF
--- a/pages/communityDetail/communityDetail.js
+++ b/pages/communityDetail/communityDetail.js
@@ -137,11 +137,30 @@ Page({
         return
       }
 
+      var payload = result.data || {}
       this.setData({
-        detail: buildDetail(this.data.moduleId, result.data || {}),
+        detail: buildDetail(this.data.moduleId, payload),
         loading: false,
         errorMessage: null
       })
+
+      // If the handler declares commentsInDetail, extract comments from the
+      // detail payload instead of making a separate getComments() request.
+      var handler = getModuleHandler(this.data.moduleId)
+      if (handler && handler.commentsInDetail) {
+        var embeddedComments = payload.photographCommentList || payload.commentList || []
+        var normalizedComments = (Array.isArray(embeddedComments) ? embeddedComments : []).map(function(item, index) {
+          return Object.assign({
+            id: item.id || item.commentId || 'comment_' + index,
+            nickname: item.nickname || i18n.t('community.list.anonStudent'),
+            comment: item.comment || '',
+            publishTime: item.publishTime || item.createTime || ''
+          }, item)
+        })
+        this.setData({ comments: normalizedComments })
+        return
+      }
+
       return this.loadComments()
     }).catch((error) => {
       this.setData({

--- a/pages/inbox/inbox.js
+++ b/pages/inbox/inbox.js
@@ -149,6 +149,7 @@ Page({
     interactionCurrentPage: 1,
     interactionFinished: false,
     interactionUnreadCount: 0,
+    interactionLoaded: false,
     errorMessage: null
   },
 
@@ -225,6 +226,12 @@ Page({
     this.setData({
       activeTab: nextTab
     })
+
+    if (nextTab === 'interaction' && !this.data.interactionLoaded) {
+      this.loadInteractionList(1, true).then(() => {
+        this.setData({ interactionLoaded: true })
+      })
+    }
   },
 
   openAnnouncementDetail: function(event) {
@@ -327,7 +334,7 @@ Page({
 
   onLoad: function() {
     this.loadAnnouncementList(1, true)
-    this.refreshInteraction()
+    this.loadInteractionMeta()
   },
 
   onShow: function() {
@@ -339,9 +346,15 @@ Page({
   },
 
   onPullDownRefresh: function() {
-    const refreshTask = this.data.activeTab === 'announcement'
-      ? this.loadAnnouncementList(1, true)
-      : this.refreshInteraction()
+    var self = this
+    var refreshTask
+    if (this.data.activeTab === 'announcement') {
+      refreshTask = this.loadAnnouncementList(1, true)
+    } else {
+      refreshTask = this.refreshInteraction().then(function() {
+        self.setData({ interactionLoaded: true })
+      })
+    }
 
     refreshTask.finally(function() {
       wx.stopPullDownRefresh()
@@ -356,7 +369,7 @@ Page({
       return
     }
 
-    if (!this.data.interactionFinished && !this.data.interactionLoading) {
+    if (this.data.interactionLoaded && !this.data.interactionFinished && !this.data.interactionLoading) {
       this.loadInteractionList(this.data.interactionCurrentPage + 1, false)
     }
   },

--- a/pages/inbox/inbox.js
+++ b/pages/inbox/inbox.js
@@ -214,6 +214,7 @@ Page({
       })
     }).catch((error) => {
       pageUtils.showTopTips(this, error.message)
+      return Promise.reject(error)
     })
   },
 
@@ -228,8 +229,11 @@ Page({
     })
 
     if (nextTab === 'interaction' && !this.data.interactionLoaded) {
-      this.loadInteractionList(1, true).then(() => {
-        this.setData({ interactionLoaded: true })
+      var self = this
+      this.loadInteractionList(1, true).then(function() {
+        self.setData({ interactionLoaded: true })
+      }).catch(function() {
+        // Keep interactionLoaded false so next tab switch retries
       })
     }
   },
@@ -353,6 +357,8 @@ Page({
     } else {
       refreshTask = this.refreshInteraction().then(function() {
         self.setData({ interactionLoaded: true })
+      }).catch(function() {
+        // Keep interactionLoaded unchanged on refresh failure
       })
     }
 

--- a/services/community/module-handlers/photograph.js
+++ b/services/community/module-handlers/photograph.js
@@ -123,6 +123,10 @@ module.exports = {
 
   searchable: false,
 
+  // Detail response already includes photographCommentList from the backend,
+  // so communityDetail can skip the separate getComments() call.
+  commentsInDetail: true,
+
   // --- Publish: validate form ---
   validateForm: function(data) {
     var form = data.form || {}

--- a/tests/inbox-lazy-interaction.test.js
+++ b/tests/inbox-lazy-interaction.test.js
@@ -1,0 +1,184 @@
+const path = require('node:path')
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { stubModule, clearModule } = require('./helpers/module.js')
+
+const ROOT = path.resolve(__dirname, '..')
+
+// --- Stubs ---
+
+// Stub wx global
+const wxCalls = []
+global.wx = {
+  setStorageSync: function() {},
+  navigateTo: function() {},
+  setNavigationBarTitle: function() {},
+  stopPullDownRefresh: function() {},
+  showModal: function() {},
+  showToast: function() {}
+}
+
+// Stub i18n
+stubModule(path.join(ROOT, 'utils/i18n.js'), {
+  t: function(key) { return key },
+  tReplace: function(key) { return key }
+})
+
+// Stub theme
+stubModule(path.join(ROOT, 'utils/theme.js'), {
+  applyTheme: function() {}
+})
+
+// Stub page utils
+stubModule(path.join(ROOT, 'utils/page.js'), {
+  runWithNavigationLoading: function(ctx, fn, opts) {
+    if (opts && opts.loadingKey) {
+      ctx.data[opts.loadingKey] = true
+    }
+    return fn().then(function(result) {
+      if (opts && opts.loadingKey) {
+        ctx.data[opts.loadingKey] = false
+      }
+      return result
+    })
+  },
+  showTopTips: function() {}
+})
+
+// Stub storage keys
+stubModule(path.join(ROOT, 'constants/storage.js'), {})
+
+// Track API calls
+var apiCallLog = []
+
+stubModule(path.join(ROOT, 'services/apis/messages.js'), {
+  getAnnouncementList: function(start, size) {
+    apiCallLog.push({ method: 'getAnnouncementList', args: [start, size] })
+    return Promise.resolve({ success: true, data: [] })
+  },
+  getInteractionList: function(start, size) {
+    apiCallLog.push({ method: 'getInteractionList', args: [start, size] })
+    return Promise.resolve({ success: true, data: [] })
+  },
+  getUnreadCount: function() {
+    apiCallLog.push({ method: 'getUnreadCount' })
+    return Promise.resolve({ success: true, data: 3 })
+  },
+  markMessageRead: function() {
+    return Promise.resolve({ success: true })
+  },
+  markAllMessagesRead: function() {
+    return Promise.resolve({ success: true })
+  }
+})
+
+// Clear and require inbox page module
+clearModule(path.join(ROOT, 'pages/inbox/inbox.js'))
+
+// We need to intercept the Page() call to capture the page config
+var capturedPageConfig = null
+global.Page = function(config) {
+  capturedPageConfig = config
+}
+
+require(path.join(ROOT, 'pages/inbox/inbox.js'))
+
+function createPageInstance() {
+  // Create a fresh page-like object with data copy and setData
+  var instance = Object.create(capturedPageConfig)
+  instance.data = JSON.parse(JSON.stringify(capturedPageConfig.data))
+  instance.setData = function(patch) {
+    Object.assign(instance.data, patch)
+  }
+  return instance
+}
+
+test('onLoad does NOT call getInteractionList', async function() {
+  apiCallLog = []
+  var page = createPageInstance()
+  page.onLoad()
+
+  // Let promises settle
+  await new Promise(function(r) { setTimeout(r, 50) })
+
+  var interactionListCalls = apiCallLog.filter(function(c) { return c.method === 'getInteractionList' })
+  var unreadCountCalls = apiCallLog.filter(function(c) { return c.method === 'getUnreadCount' })
+  var announcementCalls = apiCallLog.filter(function(c) { return c.method === 'getAnnouncementList' })
+
+  assert.equal(interactionListCalls.length, 0, 'should NOT fetch interaction list on initial load')
+  assert.equal(unreadCountCalls.length, 1, 'should fetch unread count for badge')
+  assert.equal(announcementCalls.length, 1, 'should fetch announcements')
+})
+
+test('switching to interaction tab triggers list fetch on first activation', async function() {
+  apiCallLog = []
+  var page = createPageInstance()
+  page.onLoad()
+  await new Promise(function(r) { setTimeout(r, 50) })
+
+  // Clear log after initial load
+  apiCallLog = []
+
+  // Simulate switching to interaction tab
+  page.switchTab({ currentTarget: { dataset: { key: 'interaction' } } })
+  await new Promise(function(r) { setTimeout(r, 50) })
+
+  var interactionListCalls = apiCallLog.filter(function(c) { return c.method === 'getInteractionList' })
+  assert.equal(interactionListCalls.length, 1, 'should fetch interaction list on first tab switch')
+  assert.equal(page.data.interactionLoaded, true, 'interactionLoaded flag should be true')
+})
+
+test('switching to interaction tab a second time does NOT re-fetch list', async function() {
+  apiCallLog = []
+  var page = createPageInstance()
+  page.onLoad()
+  await new Promise(function(r) { setTimeout(r, 50) })
+
+  // First switch to interaction
+  page.switchTab({ currentTarget: { dataset: { key: 'interaction' } } })
+  await new Promise(function(r) { setTimeout(r, 50) })
+
+  // Switch back to announcement
+  page.switchTab({ currentTarget: { dataset: { key: 'announcement' } } })
+  await new Promise(function(r) { setTimeout(r, 50) })
+
+  // Clear log
+  apiCallLog = []
+
+  // Switch to interaction again
+  page.switchTab({ currentTarget: { dataset: { key: 'interaction' } } })
+  await new Promise(function(r) { setTimeout(r, 50) })
+
+  var interactionListCalls = apiCallLog.filter(function(c) { return c.method === 'getInteractionList' })
+  assert.equal(interactionListCalls.length, 0, 'should NOT re-fetch interaction list on second switch')
+})
+
+test('pull-down refresh on interaction tab fetches list and sets interactionLoaded', async function() {
+  apiCallLog = []
+  var page = createPageInstance()
+  page.onLoad()
+  await new Promise(function(r) { setTimeout(r, 50) })
+
+  // Switch to interaction tab to set activeTab
+  page.setData({ activeTab: 'interaction' })
+
+  apiCallLog = []
+  page.onPullDownRefresh()
+  await new Promise(function(r) { setTimeout(r, 50) })
+
+  var interactionListCalls = apiCallLog.filter(function(c) { return c.method === 'getInteractionList' })
+  assert.equal(interactionListCalls.length, 1, 'pull-down refresh should fetch interaction list')
+  assert.equal(page.data.interactionLoaded, true, 'interactionLoaded should be true after refresh')
+})
+
+test('onReachBottom does not paginate interaction if not yet loaded', function() {
+  apiCallLog = []
+  var page = createPageInstance()
+  page.setData({ activeTab: 'interaction', interactionLoaded: false, interactionFinished: false })
+
+  page.onReachBottom()
+
+  var interactionListCalls = apiCallLog.filter(function(c) { return c.method === 'getInteractionList' })
+  assert.equal(interactionListCalls.length, 0, 'should not paginate when interactionLoaded is false')
+})

--- a/tests/photograph-detail-comments.test.js
+++ b/tests/photograph-detail-comments.test.js
@@ -1,0 +1,238 @@
+const path = require('node:path')
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { stubModule, clearModule } = require('./helpers/module.js')
+
+const ROOT = path.resolve(__dirname, '..')
+
+// --- Stubs ---
+
+global.wx = {
+  setNavigationBarTitle: function() {},
+  showModal: function() {},
+  showToast: function() {},
+  navigateTo: function() {},
+  setClipboardData: function() {},
+  makePhoneCall: function() {},
+  previewImage: function() {},
+  createInnerAudioContext: function() {
+    return { onEnded: function() {}, onStop: function() {}, onError: function() {}, stop: function() {}, destroy: function() {} }
+  }
+}
+
+stubModule(path.join(ROOT, 'utils/i18n.js'), {
+  t: function(key) { return key },
+  tReplace: function(key) { return key }
+})
+
+stubModule(path.join(ROOT, 'utils/theme.js'), {
+  applyTheme: function() {}
+})
+
+stubModule(path.join(ROOT, 'utils/page.js'), {
+  runWithNavigationLoading: function(ctx, fn) {
+    return fn()
+  },
+  showTopTips: function() {}
+})
+
+stubModule(path.join(ROOT, 'utils/debounce.js'), {
+  createSubmitGuard: function() {
+    return { acquire: function() { return true }, release: function() {} }
+  }
+})
+
+stubModule(path.join(ROOT, 'constants/profile.js'), {
+  fetchProfileOptions: function() { return Promise.resolve() }
+})
+
+// Track API calls
+var apiCallLog = []
+
+// Build handler stubs that mimic the real registry behavior
+// We need photograph handler to have commentsInDetail: true
+
+var photographHandlerStub = {
+  getFeed: function() { return Promise.resolve({ success: true, data: [] }) },
+  getDetail: function(id) {
+    apiCallLog.push({ method: 'photograph.getDetail', args: [id] })
+    return Promise.resolve({
+      success: true,
+      data: {
+        id: id,
+        title: 'Test Photo',
+        content: 'A photograph',
+        photographCommentList: [
+          { commentId: 101, nickname: 'Alice', comment: 'Great photo!', publishTime: '2026-01-01' },
+          { commentId: 102, nickname: 'Bob', comment: 'Nice!', publishTime: '2026-01-02' }
+        ]
+      }
+    })
+  },
+  getCenter: function() { return Promise.resolve({ success: true, data: [] }) },
+  getComments: function(id) {
+    apiCallLog.push({ method: 'photograph.getComments', args: [id] })
+    return Promise.resolve({
+      success: true,
+      data: [
+        { commentId: 101, nickname: 'Alice', comment: 'Great photo!', publishTime: '2026-01-01' },
+        { commentId: 102, nickname: 'Bob', comment: 'Nice!', publishTime: '2026-01-02' }
+      ]
+    })
+  },
+  buildDetailView: function(payload) {
+    return { title: payload.title || 'Detail', description: payload.content || '' }
+  },
+  buildListTabs: function() { return [] },
+  normalizeItem: function(item) { return item },
+  buildFeedOptions: function(opts) { return opts },
+  buildCenterTabs: function() { return [] },
+  normalizeCenterData: function() { return {} },
+  publish: function() { return Promise.resolve({ success: true }) },
+  validateForm: function() { return '' },
+  buildPublishPayload: function() { return Promise.resolve({}) },
+  submitComment: function() { return Promise.resolve({ success: true }) },
+  toggleLike: function() { return Promise.resolve({ success: true }) },
+  commentsInDetail: true,
+  searchable: false,
+  showSummaryProfile: false
+}
+
+var secretHandlerStub = {
+  getFeed: function() { return Promise.resolve({ success: true, data: [] }) },
+  getDetail: function(id) {
+    apiCallLog.push({ method: 'secret.getDetail', args: [id] })
+    return Promise.resolve({
+      success: true,
+      data: { id: id, content: 'A secret', type: 0 }
+    })
+  },
+  getCenter: function() { return Promise.resolve({ success: true, data: [] }) },
+  getComments: function(id) {
+    apiCallLog.push({ method: 'secret.getComments', args: [id] })
+    return Promise.resolve({ success: true, data: [] })
+  },
+  buildDetailView: function(payload) {
+    return { title: 'Secret', description: payload.content || '', canLike: true }
+  },
+  buildListTabs: function() { return [] },
+  normalizeItem: function(item) { return item },
+  buildFeedOptions: function(opts) { return opts },
+  buildCenterTabs: function() { return [] },
+  normalizeCenterData: function() { return {} },
+  publish: function() { return Promise.resolve({ success: true }) },
+  validateForm: function() { return '' },
+  buildPublishPayload: function() { return Promise.resolve({}) },
+  submitComment: function() { return Promise.resolve({ success: true }) },
+  toggleLike: function() { return Promise.resolve({ success: true }) },
+  searchable: false,
+  showSummaryProfile: false
+}
+
+// Stub registry
+stubModule(path.join(ROOT, 'services/community/registry.js'), {
+  getModuleHandler: function(moduleId) {
+    if (moduleId === 'photograph') return photographHandlerStub
+    if (moduleId === 'secret') return secretHandlerStub
+    return null
+  }
+})
+
+// Stub community API to delegate to handler stubs (mirrors real community.js)
+stubModule(path.join(ROOT, 'services/apis/community.js'), {
+  getDetail: function(moduleId, id) {
+    if (moduleId === 'photograph') return photographHandlerStub.getDetail(id)
+    if (moduleId === 'secret') return secretHandlerStub.getDetail(id)
+    return Promise.reject(new Error('unknown module'))
+  },
+  getComments: function(moduleId, id) {
+    if (moduleId === 'photograph') return photographHandlerStub.getComments(id)
+    if (moduleId === 'secret') return secretHandlerStub.getComments(id)
+    return Promise.resolve({ success: true, data: [] })
+  },
+  submitComment: function() { return Promise.resolve({ success: true }) },
+  toggleLike: function() { return Promise.resolve({ success: true }) },
+  guessExpress: function() { return Promise.resolve({ success: true }) },
+  acceptDeliveryOrder: function() { return Promise.resolve({ success: true }) },
+  finishDeliveryTrade: function() { return Promise.resolve({ success: true }) },
+  submitDatingPick: function() { return Promise.resolve({ success: true }) }
+})
+
+// Stub community constants
+stubModule(path.join(ROOT, 'constants/community.js'), {
+  getCommunityModule: function(moduleId) {
+    if (moduleId === 'photograph') return { title: 'Photograph', moduleId: 'photograph' }
+    if (moduleId === 'secret') return { title: 'Secret', moduleId: 'secret' }
+    return null
+  },
+  getCommunityPageTitle: function(moduleId, page, fallback) { return fallback || moduleId }
+})
+
+// Now require communityDetail
+clearModule(path.join(ROOT, 'pages/communityDetail/communityDetail.js'))
+
+var capturedPageConfig = null
+global.Page = function(config) {
+  capturedPageConfig = config
+}
+
+require(path.join(ROOT, 'pages/communityDetail/communityDetail.js'))
+
+function createPageInstance() {
+  var instance = Object.create(capturedPageConfig)
+  instance.data = JSON.parse(JSON.stringify(capturedPageConfig.data))
+  instance.setData = function(patch) {
+    Object.assign(instance.data, patch)
+  }
+  return instance
+}
+
+test('photograph detail does NOT make separate getComments call', async function() {
+  apiCallLog = []
+  var page = createPageInstance()
+  page.onLoad({ module: 'photograph', id: '42' })
+
+  await new Promise(function(r) { setTimeout(r, 100) })
+
+  var detailCalls = apiCallLog.filter(function(c) { return c.method === 'photograph.getDetail' })
+  var commentCalls = apiCallLog.filter(function(c) { return c.method === 'photograph.getComments' })
+
+  assert.equal(detailCalls.length, 1, 'should fetch photograph detail once')
+  assert.equal(commentCalls.length, 0, 'should NOT make separate getComments call for photograph')
+})
+
+test('photograph detail extracts comments from detail response', async function() {
+  apiCallLog = []
+  var page = createPageInstance()
+  page.onLoad({ module: 'photograph', id: '42' })
+
+  await new Promise(function(r) { setTimeout(r, 100) })
+
+  assert.equal(page.data.comments.length, 2, 'should have 2 comments from detail response')
+  assert.equal(page.data.comments[0].id, 101)
+  assert.equal(page.data.comments[0].nickname, 'Alice')
+  assert.equal(page.data.comments[0].comment, 'Great photo!')
+  assert.equal(page.data.comments[1].id, 102)
+  assert.equal(page.data.comments[1].nickname, 'Bob')
+})
+
+test('secret detail still makes separate getComments call', async function() {
+  apiCallLog = []
+  var page = createPageInstance()
+  page.onLoad({ module: 'secret', id: '10' })
+
+  await new Promise(function(r) { setTimeout(r, 100) })
+
+  var detailCalls = apiCallLog.filter(function(c) { return c.method === 'secret.getDetail' })
+  var commentCalls = apiCallLog.filter(function(c) { return c.method === 'secret.getComments' })
+
+  assert.equal(detailCalls.length, 1, 'should fetch secret detail once')
+  assert.equal(commentCalls.length, 1, 'should still make separate getComments call for secret')
+})
+
+test('photograph handler has commentsInDetail flag set to true', function() {
+  var { getModuleHandler } = require(path.join(ROOT, 'services/community/registry.js'))
+  var handler = getModuleHandler('photograph')
+  assert.equal(handler.commentsInDetail, true, 'photograph handler should have commentsInDetail: true')
+})


### PR DESCRIPTION
## Summary
- Task D: Defer interaction list fetch until user switches to interaction tab
  - Fix: interactionLoaded only set on success, allowing retry on failure
- Task E: Skip duplicate getComments() for photograph (detail already includes comments)
- Add 9 tests (5 inbox lazy + 4 photograph dedup)

## Test plan
- [x] `node --test` — 76 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)