### PR TITLE
test: rename performance tests to explicit request-count contracts

### DIFF
--- a/tests/inbox-lazy-interaction.test.js
+++ b/tests/inbox-lazy-interaction.test.js
@@ -94,7 +94,7 @@ function createPageInstance() {
   return instance
 }
 
-test('onLoad does NOT call getInteractionList', async function() {
+test('initial load does NOT call interaction list — zero getInteractionList requests on onLoad', async function() {
   apiCallLog = []
   var page = createPageInstance()
   page.onLoad()

--- a/tests/photograph-detail-comments.test.js
+++ b/tests/photograph-detail-comments.test.js
@@ -188,7 +188,7 @@ function createPageInstance() {
   return instance
 }
 
-test('photograph detail does NOT make separate getComments call', async function() {
+test('photograph detail makes no separate getComments call — comments are embedded in detail response', async function() {
   apiCallLog = []
   var page = createPageInstance()
   page.onLoad({ module: 'photograph', id: '42' })


### PR DESCRIPTION
## Summary
- Rename inbox lazy-load and photograph detail tests to describe request-count contracts explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)