### PR TITLE
perf: remove duplicate onLoad data fetches on index page

### DIFF
--- a/pages/index/index.js
+++ b/pages/index/index.js
@@ -148,11 +148,7 @@ Page({
   },
 
   onLoad: function() {
-    this.refreshI18n()
-    this.loadProfile()
-    this.loadInboxStatus()
     this.setData({ hiddenFeatureIds: [] })
-    this.loadHomeSections()
   },
 
   onShow: function() {


### PR DESCRIPTION
## Summary
- onLoad + onShow both called loadProfile/loadInboxStatus/refreshI18n/loadHomeSections
- Moved all to onShow only (WeChat fires onShow after onLoad on first entry)
- Eliminates 4 redundant network requests per index page load

## Test plan
- [x] `node --test` — 76 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)