### PR TITLE
feat: request correlation, auth/validate, tests, CI

### DIFF
--- a/.github/workflows/wechat-ci.yml
+++ b/.github/workflows/wechat-ci.yml
@@ -1,0 +1,37 @@
+name: WeChat Mini Program CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - 'release/**'
+  pull_request:
+    branches:
+      - main
+      - master
+      - 'release/**'
+
+jobs:
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Print Node version
+        run: node --version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ GdeiAssistant-WechatApp/
 
 - 微信开发者工具
 - 微信小程序基础库 `>= 2.32.3`
+- Node.js `>= 18`（运行测试）
 
 ## 快速开始
 
@@ -137,6 +138,15 @@ GdeiAssistant-WechatApp/
 ### 3. 编译运行
 
 在微信开发者工具中编译并预览页面。
+
+### 4. 运行测试
+
+```bash
+npm install
+npm test
+```
+
+测试使用 Node 内建 test runner，无需额外依赖。`npm test` 会运行 `tests/` 下所有 `*.test.js` 文件。
 
 ## Mock 模式说明
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -344,7 +344,32 @@
     "shareTitle": "Card Transactions"
   },
   "bookPage": {
-    "navTitle": "My Loans"
+    "navTitle": "My Loans",
+    "passwordLabel": "Library Password",
+    "passwordPlaceholder": "Enter library password",
+    "passwordRequired": "Please enter library password",
+    "queryFailed": "Query failed",
+    "tip": "Enter your library password to view loans. The password will be re-verified when renewing.",
+    "refreshBorrow": "Refresh Loans",
+    "queryBorrow": "Query Loans",
+    "emptyHint": "Enter your library password to view current loan records.",
+    "emptyResult": "No loan records to display.",
+    "borrowListTitle": "Loan List",
+    "barcode": "Barcode",
+    "snNumber": "SN",
+    "author": "Author",
+    "borrowDate": "Borrow Date",
+    "returnDate": "Due Date",
+    "renewCount": "Renewals",
+    "renewButton": "Renew",
+    "renewDialogTitle": "Renew Book",
+    "renewDialogMessage": "Enter your library password to verify renewal. Password is only used for this request.",
+    "renewFailed": "Renewal failed",
+    "renewRefreshFailed": "Failed to refresh loan records",
+    "renewSuccessTitle": "Renewed Successfully",
+    "renewSuccessContent": "Book has been renewed",
+    "confirmRenew": "Confirm Renewal",
+    "shareTitle": "Library"
   },
   "graduateExamPage": {
     "navTitle": "Postgrad Exam",
@@ -370,7 +395,11 @@
     "shareTitle": "Postgrad Exam"
   },
   "dataPage": {
-    "navTitle": "Data Query"
+    "navTitle": "Data Query",
+    "selectProject": "Select Query",
+    "electricityQuery": "Electricity Bill",
+    "yellowPageQuery": "Yellow Pages",
+    "shareTitle": "Data Query"
   },
   "cardLostPage": {
     "navTitle": "Report Lost Card",
@@ -384,7 +413,28 @@
     "shareTitle": "Report Lost Card"
   },
   "electricityPage": {
-    "navTitle": "Electricity Bill"
+    "navTitle": "Electricity Bill",
+    "queryInfo": "Query Info",
+    "yearLabel": "Year",
+    "nameLabel": "Name",
+    "namePlaceholder": "Enter name",
+    "studentIdLabel": "Student ID",
+    "studentIdPlaceholder": "Enter student ID",
+    "fillAllFields": "Please enter name and student ID",
+    "invalidStudentId": "Please enter a valid student ID",
+    "queryButton": "Query",
+    "resultTitle": "Electricity Info",
+    "dormitory": "Dormitory",
+    "occupants": "Occupants",
+    "department": "Department",
+    "usedAmount": "Usage",
+    "freeAmount": "Free Allowance",
+    "chargedAmount": "Billed Usage",
+    "price": "Unit Price",
+    "totalBill": "Total Bill",
+    "averageBill": "Average Bill",
+    "reQuery": "Query Again",
+    "shareTitle": "Electricity Bill"
   },
   "collectionPage": {
     "navTitle": "Library",
@@ -402,7 +452,39 @@
     "shareTitle": "Library"
   },
   "yellowPagePage": {
-    "navTitle": "Yellow Pages"
+    "navTitle": "Yellow Pages",
+    "shareTitle": "Yellow Pages"
+  },
+  "newsDetailPage": {
+    "loadingDetail": "Loading details",
+    "loadFailed": "Failed to load details",
+    "noContent": "No content available",
+    "announcement": "Announcement",
+    "news": "News"
+  },
+  "collectionDetailPage": {
+    "basicInfo": "Basic Info",
+    "bookName": "Title",
+    "author": "Author",
+    "heading": "Heading",
+    "responsible": "Responsible",
+    "headingResponsible": "Heading / Responsible",
+    "publisher": "Publisher",
+    "publishYear": "Year",
+    "publisherYear": "Publisher / Year",
+    "isbn": "ISBN",
+    "fixedPrice": "Price",
+    "isbnPrice": "ISBN / Price",
+    "physicalDesc": "Physical Description",
+    "personalResp": "Personal Responsibility",
+    "subjectTheme": "Subject",
+    "clcNumber": "CLC Number",
+    "collectionInfo": "Collection Info",
+    "location": "Location",
+    "callNumber": "Call Number",
+    "barcodeNumber": "Barcode",
+    "status": "Status",
+    "shareTitle": "Collection Detail"
   },
   "evaluatePage": {
     "navTitle": "Evaluation",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -441,7 +441,32 @@
     "shareTitle": "学生証利用履歴"
   },
   "bookPage": {
-    "navTitle": "マイ貸出"
+    "navTitle": "マイ貸出",
+    "passwordLabel": "図書館パスワード",
+    "passwordPlaceholder": "図書館パスワードを入力",
+    "passwordRequired": "図書館パスワードを入力してください",
+    "queryFailed": "検索に失敗しました",
+    "tip": "貸出照会には図書館パスワードが必要です。更新時に再度検証されます。",
+    "refreshBorrow": "貸出を更新",
+    "queryBorrow": "貸出を照会",
+    "emptyHint": "図書館パスワードを入力すると貸出記録を表示できます。",
+    "emptyResult": "表示できる貸出記録がありません。",
+    "borrowListTitle": "貸出一覧",
+    "barcode": "バーコード",
+    "snNumber": "SN番号",
+    "author": "著者",
+    "borrowDate": "貸出日",
+    "returnDate": "返却期限",
+    "renewCount": "更新回数",
+    "renewButton": "更新",
+    "renewDialogTitle": "図書更新",
+    "renewDialogMessage": "図書館パスワードを入力して更新を確認してください。パスワードは今回のみ使用されます。",
+    "renewFailed": "更新に失敗しました",
+    "renewRefreshFailed": "貸出記録の更新に失敗しました",
+    "renewSuccessTitle": "更新完了",
+    "renewSuccessContent": "図書の更新が完了しました",
+    "confirmRenew": "更新を確認",
+    "shareTitle": "図書館"
   },
   "graduateExamPage": {
     "navTitle": "大学院入試照会",
@@ -467,7 +492,11 @@
     "shareTitle": "大学院入試照会"
   },
   "dataPage": {
-    "navTitle": "データ照会"
+    "navTitle": "データ照会",
+    "selectProject": "照会項目を選択",
+    "electricityQuery": "電気料金照会",
+    "yellowPageQuery": "電話帳検索",
+    "shareTitle": "データ照会"
   },
   "cardLostPage": {
     "navTitle": "紛失届",
@@ -481,7 +510,28 @@
     "shareTitle": "紛失届"
   },
   "electricityPage": {
-    "navTitle": "電気料金照会"
+    "navTitle": "電気料金照会",
+    "queryInfo": "検索情報",
+    "yearLabel": "年度",
+    "nameLabel": "氏名",
+    "namePlaceholder": "氏名を入力",
+    "studentIdLabel": "学籍番号",
+    "studentIdPlaceholder": "学籍番号を入力",
+    "fillAllFields": "氏名と学籍番号を入力してください",
+    "invalidStudentId": "正しい学籍番号を入力してください",
+    "queryButton": "検索",
+    "resultTitle": "電気料金情報",
+    "dormitory": "寮",
+    "occupants": "入居人数",
+    "department": "学部",
+    "usedAmount": "使用量",
+    "freeAmount": "無料枠",
+    "chargedAmount": "課金対象量",
+    "price": "単価",
+    "totalBill": "合計料金",
+    "averageBill": "平均料金",
+    "reQuery": "再検索",
+    "shareTitle": "電気料金照会"
   },
   "collectionPage": {
     "navTitle": "図書館",
@@ -499,7 +549,39 @@
     "shareTitle": "図書館"
   },
   "yellowPagePage": {
-    "navTitle": "電話帳検索"
+    "navTitle": "電話帳検索",
+    "shareTitle": "電話帳検索"
+  },
+  "newsDetailPage": {
+    "loadingDetail": "詳細を読み込み中",
+    "loadFailed": "詳細の読み込みに失敗しました",
+    "noContent": "詳細内容がありません",
+    "announcement": "システム通知",
+    "news": "ニュース"
+  },
+  "collectionDetailPage": {
+    "basicInfo": "基本情報",
+    "bookName": "書名",
+    "author": "著者",
+    "heading": "題名",
+    "responsible": "責任者",
+    "headingResponsible": "題名/責任者",
+    "publisher": "出版社",
+    "publishYear": "出版年",
+    "publisherYear": "出版社/出版年",
+    "isbn": "ISBN",
+    "fixedPrice": "定価",
+    "isbnPrice": "ISBN/定価",
+    "physicalDesc": "形態",
+    "personalResp": "個人責任者",
+    "subjectTheme": "主題",
+    "clcNumber": "分類番号",
+    "collectionInfo": "所蔵情報",
+    "location": "所蔵場所",
+    "callNumber": "請求記号",
+    "barcodeNumber": "バーコード番号",
+    "status": "状態",
+    "shareTitle": "所蔵詳細"
   },
   "evaluatePage": {
     "navTitle": "授業評価",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -441,7 +441,32 @@
     "shareTitle": "학생증 거래 내역"
   },
   "bookPage": {
-    "navTitle": "내 대출"
+    "navTitle": "내 대출",
+    "passwordLabel": "도서관 비밀번호",
+    "passwordPlaceholder": "도서관 비밀번호를 입력하세요",
+    "passwordRequired": "도서관 비밀번호를 입력하세요",
+    "queryFailed": "조회 실패",
+    "tip": "대출 조회를 위해 도서관 비밀번호를 입력하세요. 연장 시 다시 확인됩니다.",
+    "refreshBorrow": "대출 새로고침",
+    "queryBorrow": "대출 조회",
+    "emptyHint": "도서관 비밀번호를 입력하면 현재 대출 기록을 확인할 수 있습니다.",
+    "emptyResult": "표시할 대출 기록이 없습니다.",
+    "borrowListTitle": "대출 목록",
+    "barcode": "바코드",
+    "snNumber": "SN번호",
+    "author": "저자",
+    "borrowDate": "대출일",
+    "returnDate": "반납 기한",
+    "renewCount": "연장 횟수",
+    "renewButton": "연장",
+    "renewDialogTitle": "도서 연장",
+    "renewDialogMessage": "도서관 비밀번호를 입력하여 연장을 확인하세요. 비밀번호는 이번 요청에만 사용됩니다.",
+    "renewFailed": "연장 실패",
+    "renewRefreshFailed": "대출 기록 새로고침 실패",
+    "renewSuccessTitle": "연장 완료",
+    "renewSuccessContent": "도서 연장이 완료되었습니다",
+    "confirmRenew": "연장 확인",
+    "shareTitle": "도서관"
   },
   "graduateExamPage": {
     "navTitle": "대학원 시험 조회",
@@ -467,7 +492,11 @@
     "shareTitle": "대학원 시험 조회"
   },
   "dataPage": {
-    "navTitle": "데이터 조회"
+    "navTitle": "데이터 조회",
+    "selectProject": "조회 항목 선택",
+    "electricityQuery": "전기요금 조회",
+    "yellowPageQuery": "전화번호부 검색",
+    "shareTitle": "데이터 조회"
   },
   "cardLostPage": {
     "navTitle": "분실 신고",
@@ -481,7 +510,28 @@
     "shareTitle": "분실 신고"
   },
   "electricityPage": {
-    "navTitle": "전기요금 조회"
+    "navTitle": "전기요금 조회",
+    "queryInfo": "조회 정보",
+    "yearLabel": "연도",
+    "nameLabel": "이름",
+    "namePlaceholder": "이름을 입력하세요",
+    "studentIdLabel": "학번",
+    "studentIdPlaceholder": "학번을 입력하세요",
+    "fillAllFields": "이름과 학번을 모두 입력하세요",
+    "invalidStudentId": "올바른 학번을 입력하세요",
+    "queryButton": "조회",
+    "resultTitle": "전기요금 정보",
+    "dormitory": "기숙사",
+    "occupants": "입주 인원",
+    "department": "학과",
+    "usedAmount": "사용량",
+    "freeAmount": "무료 한도",
+    "chargedAmount": "과금 사용량",
+    "price": "단가",
+    "totalBill": "총 요금",
+    "averageBill": "평균 요금",
+    "reQuery": "다시 조회",
+    "shareTitle": "전기요금 조회"
   },
   "collectionPage": {
     "navTitle": "도서관",
@@ -499,7 +549,39 @@
     "shareTitle": "도서관"
   },
   "yellowPagePage": {
-    "navTitle": "전화번호부 검색"
+    "navTitle": "전화번호부 검색",
+    "shareTitle": "전화번호부 검색"
+  },
+  "newsDetailPage": {
+    "loadingDetail": "상세 정보 로딩 중",
+    "loadFailed": "상세 정보 로딩 실패",
+    "noContent": "상세 내용이 없습니다",
+    "announcement": "시스템 공지",
+    "news": "뉴스"
+  },
+  "collectionDetailPage": {
+    "basicInfo": "기본 정보",
+    "bookName": "도서명",
+    "author": "저자",
+    "heading": "표제",
+    "responsible": "책임자",
+    "headingResponsible": "표제/책임자",
+    "publisher": "출판사",
+    "publishYear": "출판년도",
+    "publisherYear": "출판사/출판년도",
+    "isbn": "ISBN",
+    "fixedPrice": "정가",
+    "isbnPrice": "ISBN/정가",
+    "physicalDesc": "형태사항",
+    "personalResp": "개인 책임자",
+    "subjectTheme": "주제",
+    "clcNumber": "분류번호",
+    "collectionInfo": "소장 정보",
+    "location": "소장처",
+    "callNumber": "청구기호",
+    "barcodeNumber": "바코드 번호",
+    "status": "상태",
+    "shareTitle": "소장 상세"
   },
   "evaluatePage": {
     "navTitle": "수업 평가",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -344,7 +344,32 @@
     "shareTitle": "校园卡消费"
   },
   "bookPage": {
-    "navTitle": "我的借阅"
+    "navTitle": "我的借阅",
+    "passwordLabel": "图书馆密码",
+    "passwordPlaceholder": "请输入图书馆密码",
+    "passwordRequired": "请输入图书馆密码",
+    "queryFailed": "查询失败",
+    "tip": "我的借阅需要先输入图书馆密码查询，续借时会再次校验密码。",
+    "refreshBorrow": "刷新借阅",
+    "queryBorrow": "查询借阅",
+    "emptyHint": "输入图书馆密码后即可查看当前借阅记录。",
+    "emptyResult": "当前没有可展示的借阅记录。",
+    "borrowListTitle": "借阅列表",
+    "barcode": "条形码",
+    "snNumber": "SN号",
+    "author": "作者",
+    "borrowDate": "借阅时间",
+    "returnDate": "应还时间",
+    "renewCount": "续借次数",
+    "renewButton": "续借",
+    "renewDialogTitle": "图书续借",
+    "renewDialogMessage": "请输入图书馆密码完成续借校验，密码只用于本次请求。",
+    "renewFailed": "续借失败",
+    "renewRefreshFailed": "借阅记录刷新失败",
+    "renewSuccessTitle": "续借成功",
+    "renewSuccessContent": "已成功续借图书",
+    "confirmRenew": "确认续借",
+    "shareTitle": "图书馆"
   },
   "graduateExamPage": {
     "navTitle": "考研查询",
@@ -370,7 +395,11 @@
     "shareTitle": "考研查询"
   },
   "dataPage": {
-    "navTitle": "数据查询"
+    "navTitle": "数据查询",
+    "selectProject": "选择查询项目",
+    "electricityQuery": "电费查询",
+    "yellowPageQuery": "黄页查询",
+    "shareTitle": "数据查询"
   },
   "cardLostPage": {
     "navTitle": "校园卡挂失",
@@ -384,7 +413,28 @@
     "shareTitle": "校园卡挂失"
   },
   "electricityPage": {
-    "navTitle": "电费查询"
+    "navTitle": "电费查询",
+    "queryInfo": "查询信息",
+    "yearLabel": "年份",
+    "nameLabel": "姓名",
+    "namePlaceholder": "请输入姓名",
+    "studentIdLabel": "学号",
+    "studentIdPlaceholder": "请输入学号",
+    "fillAllFields": "请完整填写姓名和学号",
+    "invalidStudentId": "请输入正确的学号",
+    "queryButton": "查询",
+    "resultTitle": "电费信息",
+    "dormitory": "宿舍",
+    "occupants": "入住人数",
+    "department": "学院",
+    "usedAmount": "用电数额",
+    "freeAmount": "免费电额",
+    "chargedAmount": "计费电数",
+    "price": "电价",
+    "totalBill": "总电费",
+    "averageBill": "平均电费",
+    "reQuery": "重新查询",
+    "shareTitle": "电费查询"
   },
   "collectionPage": {
     "navTitle": "图书馆",
@@ -402,7 +452,39 @@
     "shareTitle": "图书馆"
   },
   "yellowPagePage": {
-    "navTitle": "黄页查询"
+    "navTitle": "黄页查询",
+    "shareTitle": "黄页查询"
+  },
+  "newsDetailPage": {
+    "loadingDetail": "正在加载详情",
+    "loadFailed": "加载详情失败",
+    "noContent": "暂无详细内容",
+    "announcement": "系统公告",
+    "news": "新闻"
+  },
+  "collectionDetailPage": {
+    "basicInfo": "基本信息",
+    "bookName": "书名",
+    "author": "作者",
+    "heading": "题名",
+    "responsible": "负责者",
+    "headingResponsible": "题名/负责者",
+    "publisher": "出版社",
+    "publishYear": "出版年",
+    "publisherYear": "出版社/出版年",
+    "isbn": "ISBN",
+    "fixedPrice": "定价",
+    "isbnPrice": "ISBN/定价",
+    "physicalDesc": "载体形态项",
+    "personalResp": "个人责任者",
+    "subjectTheme": "学科主题",
+    "clcNumber": "中图法分类号",
+    "collectionInfo": "馆藏信息",
+    "location": "馆藏地",
+    "callNumber": "索取号",
+    "barcodeNumber": "条码号",
+    "status": "状态",
+    "shareTitle": "馆藏详情"
   },
   "evaluatePage": {
     "navTitle": "一键评教",

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -441,7 +441,32 @@
     "shareTitle": "校園卡消費"
   },
   "bookPage": {
-    "navTitle": "我的借閱"
+    "navTitle": "我的借閱",
+    "passwordLabel": "圖書館密碼",
+    "passwordPlaceholder": "請輸入圖書館密碼",
+    "passwordRequired": "請輸入圖書館密碼",
+    "queryFailed": "查詢失敗",
+    "tip": "我的借閱需要先輸入圖書館密碼查詢，續借時會再次校驗密碼。",
+    "refreshBorrow": "刷新借閱",
+    "queryBorrow": "查詢借閱",
+    "emptyHint": "輸入圖書館密碼後即可查看當前借閱記錄。",
+    "emptyResult": "當前沒有可展示的借閱記錄。",
+    "borrowListTitle": "借閱列表",
+    "barcode": "條形碼",
+    "snNumber": "SN號",
+    "author": "作者",
+    "borrowDate": "借閱時間",
+    "returnDate": "應還時間",
+    "renewCount": "續借次數",
+    "renewButton": "續借",
+    "renewDialogTitle": "圖書續借",
+    "renewDialogMessage": "請輸入圖書館密碼完成續借校驗，密碼只用於本次請求。",
+    "renewFailed": "續借失敗",
+    "renewRefreshFailed": "借閱記錄刷新失敗",
+    "renewSuccessTitle": "續借成功",
+    "renewSuccessContent": "已成功續借圖書",
+    "confirmRenew": "確認續借",
+    "shareTitle": "圖書館"
   },
   "graduateExamPage": {
     "navTitle": "考研查詢",
@@ -467,7 +492,11 @@
     "shareTitle": "考研查詢"
   },
   "dataPage": {
-    "navTitle": "數據查詢"
+    "navTitle": "數據查詢",
+    "selectProject": "選擇查詢項目",
+    "electricityQuery": "電費查詢",
+    "yellowPageQuery": "黃頁查詢",
+    "shareTitle": "數據查詢"
   },
   "cardLostPage": {
     "navTitle": "校園卡掛失",
@@ -481,7 +510,28 @@
     "shareTitle": "校園卡掛失"
   },
   "electricityPage": {
-    "navTitle": "電費查詢"
+    "navTitle": "電費查詢",
+    "queryInfo": "查詢資訊",
+    "yearLabel": "年份",
+    "nameLabel": "姓名",
+    "namePlaceholder": "請輸入姓名",
+    "studentIdLabel": "學號",
+    "studentIdPlaceholder": "請輸入學號",
+    "fillAllFields": "請完整填寫姓名和學號",
+    "invalidStudentId": "請輸入正確的學號",
+    "queryButton": "查詢",
+    "resultTitle": "電費資訊",
+    "dormitory": "宿舍",
+    "occupants": "入住人數",
+    "department": "學院",
+    "usedAmount": "用電數額",
+    "freeAmount": "免費電額",
+    "chargedAmount": "計費電數",
+    "price": "電價",
+    "totalBill": "總電費",
+    "averageBill": "平均電費",
+    "reQuery": "重新查詢",
+    "shareTitle": "電費查詢"
   },
   "collectionPage": {
     "navTitle": "圖書館",
@@ -499,7 +549,39 @@
     "shareTitle": "圖書館"
   },
   "yellowPagePage": {
-    "navTitle": "黃頁查詢"
+    "navTitle": "黃頁查詢",
+    "shareTitle": "黃頁查詢"
+  },
+  "newsDetailPage": {
+    "loadingDetail": "正在載入詳情",
+    "loadFailed": "載入詳情失敗",
+    "noContent": "暫無詳細內容",
+    "announcement": "系統公告",
+    "news": "新聞"
+  },
+  "collectionDetailPage": {
+    "basicInfo": "基本資訊",
+    "bookName": "書名",
+    "author": "作者",
+    "heading": "題名",
+    "responsible": "負責者",
+    "headingResponsible": "題名/負責者",
+    "publisher": "出版社",
+    "publishYear": "出版年",
+    "publisherYear": "出版社/出版年",
+    "isbn": "ISBN",
+    "fixedPrice": "定價",
+    "isbnPrice": "ISBN/定價",
+    "physicalDesc": "載體形態項",
+    "personalResp": "個人責任者",
+    "subjectTheme": "學科主題",
+    "clcNumber": "中圖法分類號",
+    "collectionInfo": "館藏資訊",
+    "location": "館藏地",
+    "callNumber": "索取號",
+    "barcodeNumber": "條碼號",
+    "status": "狀態",
+    "shareTitle": "館藏詳情"
   },
   "evaluatePage": {
     "navTitle": "一鍵評教",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -441,7 +441,32 @@
     "shareTitle": "校園卡消費"
   },
   "bookPage": {
-    "navTitle": "我的借閱"
+    "navTitle": "我的借閱",
+    "passwordLabel": "圖書館密碼",
+    "passwordPlaceholder": "請輸入圖書館密碼",
+    "passwordRequired": "請輸入圖書館密碼",
+    "queryFailed": "查詢失敗",
+    "tip": "我的借閱需要先輸入圖書館密碼查詢，續借時會再次驗證密碼。",
+    "refreshBorrow": "重新整理借閱",
+    "queryBorrow": "查詢借閱",
+    "emptyHint": "輸入圖書館密碼後即可查看目前借閱紀錄。",
+    "emptyResult": "目前沒有可展示的借閱紀錄。",
+    "borrowListTitle": "借閱列表",
+    "barcode": "條碼",
+    "snNumber": "SN號",
+    "author": "作者",
+    "borrowDate": "借閱時間",
+    "returnDate": "應還時間",
+    "renewCount": "續借次數",
+    "renewButton": "續借",
+    "renewDialogTitle": "圖書續借",
+    "renewDialogMessage": "請輸入圖書館密碼完成續借驗證，密碼僅用於本次請求。",
+    "renewFailed": "續借失敗",
+    "renewRefreshFailed": "借閱紀錄重新整理失敗",
+    "renewSuccessTitle": "續借成功",
+    "renewSuccessContent": "已成功續借圖書",
+    "confirmRenew": "確認續借",
+    "shareTitle": "圖書館"
   },
   "graduateExamPage": {
     "navTitle": "考研查詢",
@@ -467,7 +492,11 @@
     "shareTitle": "考研查詢"
   },
   "dataPage": {
-    "navTitle": "資料查詢"
+    "navTitle": "資料查詢",
+    "selectProject": "選擇查詢項目",
+    "electricityQuery": "電費查詢",
+    "yellowPageQuery": "黃頁查詢",
+    "shareTitle": "資料查詢"
   },
   "cardLostPage": {
     "navTitle": "校園卡掛失",
@@ -481,7 +510,28 @@
     "shareTitle": "校園卡掛失"
   },
   "electricityPage": {
-    "navTitle": "電費查詢"
+    "navTitle": "電費查詢",
+    "queryInfo": "查詢資訊",
+    "yearLabel": "年份",
+    "nameLabel": "姓名",
+    "namePlaceholder": "請輸入姓名",
+    "studentIdLabel": "學號",
+    "studentIdPlaceholder": "請輸入學號",
+    "fillAllFields": "請完整填寫姓名和學號",
+    "invalidStudentId": "請輸入正確的學號",
+    "queryButton": "查詢",
+    "resultTitle": "電費資訊",
+    "dormitory": "宿舍",
+    "occupants": "入住人數",
+    "department": "學院",
+    "usedAmount": "用電數額",
+    "freeAmount": "免費電額",
+    "chargedAmount": "計費電數",
+    "price": "電價",
+    "totalBill": "總電費",
+    "averageBill": "平均電費",
+    "reQuery": "重新查詢",
+    "shareTitle": "電費查詢"
   },
   "collectionPage": {
     "navTitle": "圖書館",
@@ -499,7 +549,39 @@
     "shareTitle": "圖書館"
   },
   "yellowPagePage": {
-    "navTitle": "黃頁查詢"
+    "navTitle": "黃頁查詢",
+    "shareTitle": "黃頁查詢"
+  },
+  "newsDetailPage": {
+    "loadingDetail": "正在載入詳情",
+    "loadFailed": "載入詳情失敗",
+    "noContent": "暫無詳細內容",
+    "announcement": "系統公告",
+    "news": "新聞"
+  },
+  "collectionDetailPage": {
+    "basicInfo": "基本資訊",
+    "bookName": "書名",
+    "author": "作者",
+    "heading": "題名",
+    "responsible": "負責者",
+    "headingResponsible": "題名/負責者",
+    "publisher": "出版社",
+    "publishYear": "出版年",
+    "publisherYear": "出版社/出版年",
+    "isbn": "ISBN",
+    "fixedPrice": "定價",
+    "isbnPrice": "ISBN/定價",
+    "physicalDesc": "載體形態項",
+    "personalResp": "個人責任者",
+    "subjectTheme": "學科主題",
+    "clcNumber": "中圖法分類號",
+    "collectionInfo": "館藏資訊",
+    "location": "館藏地",
+    "callNumber": "索取號",
+    "barcodeNumber": "條碼號",
+    "status": "狀態",
+    "shareTitle": "館藏詳情"
   },
   "evaluatePage": {
     "navTitle": "一鍵評量",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "gdeiassistant-wechatapp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gdeiassistant-wechatapp",
+      "version": "1.0.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gdeiassistant-wechatapp",
+  "version": "1.0.0",
+  "private": true,
+  "description": "广东二师助手微信小程序",
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/pages/book/book.js
+++ b/pages/book/book.js
@@ -12,7 +12,33 @@ Page({
   refreshI18n: function () {
     this.setData({
       t: {
-        navTitle: i18n.t('bookPage.navTitle')
+        navTitle: i18n.t('bookPage.navTitle'),
+        passwordLabel: i18n.t('bookPage.passwordLabel'),
+        passwordPlaceholder: i18n.t('bookPage.passwordPlaceholder'),
+        passwordRequired: i18n.t('bookPage.passwordRequired'),
+        queryFailed: i18n.t('bookPage.queryFailed'),
+        tip: i18n.t('bookPage.tip'),
+        refreshBorrow: i18n.t('bookPage.refreshBorrow'),
+        queryBorrow: i18n.t('bookPage.queryBorrow'),
+        emptyHint: i18n.t('bookPage.emptyHint'),
+        emptyResult: i18n.t('bookPage.emptyResult'),
+        borrowListTitle: i18n.t('bookPage.borrowListTitle'),
+        barcode: i18n.t('bookPage.barcode'),
+        snNumber: i18n.t('bookPage.snNumber'),
+        author: i18n.t('bookPage.author'),
+        borrowDate: i18n.t('bookPage.borrowDate'),
+        returnDate: i18n.t('bookPage.returnDate'),
+        renewCount: i18n.t('bookPage.renewCount'),
+        renewButton: i18n.t('bookPage.renewButton'),
+        renewDialogTitle: i18n.t('bookPage.renewDialogTitle'),
+        renewDialogMessage: i18n.t('bookPage.renewDialogMessage'),
+        renewFailed: i18n.t('bookPage.renewFailed'),
+        renewRefreshFailed: i18n.t('bookPage.renewRefreshFailed'),
+        renewSuccessTitle: i18n.t('bookPage.renewSuccessTitle'),
+        renewSuccessContent: i18n.t('bookPage.renewSuccessContent'),
+        confirmRenew: i18n.t('bookPage.confirmRenew'),
+        cancel: i18n.t('common.cancel'),
+        shareTitle: i18n.t('bookPage.shareTitle')
       }
     })
     wx.setNavigationBarTitle({ title: this.data.t.navTitle })
@@ -43,7 +69,7 @@ Page({
   submit: function(e) {
     const password = String((e.detail.value && e.detail.value.password) || this.data.password || '').trim()
     if (!password) {
-      pageUtils.showTopTips(this, '请输入图书馆密码')
+      pageUtils.showTopTips(this, this.data.t.passwordRequired)
       return Promise.resolve()
     }
 
@@ -62,12 +88,12 @@ Page({
           errorMessage: null
         })
       } else {
-        throw new Error(result.message || '查询失败')
+        throw new Error(result.message || this.data.t.queryFailed)
       }
     }).catch((error) => {
-      pageUtils.showTopTips(this, error.message || '查询失败')
+      pageUtils.showTopTips(this, error.message || this.data.t.queryFailed)
       this.setData({
-        errorMessage: error.message || '查询失败'
+        errorMessage: error.message || this.data.t.queryFailed
       })
     })
   },
@@ -109,7 +135,7 @@ Page({
     const password = String(this.data.renewPassword || '').trim()
 
     if (!password) {
-      this.setData({ renewErrorMessage: '请输入图书馆密码' })
+      this.setData({ renewErrorMessage: this.data.t.passwordRequired })
       return
     }
 
@@ -125,10 +151,10 @@ Page({
         })
         return libraryApi.queryBook(password)
       }
-      throw new Error(result.message || '续借失败')
+      throw new Error(result.message || this.data.t.renewFailed)
     }).then((result) => {
       if (!result || !result.success) {
-        throw new Error((result && result.message) || '借阅记录刷新失败')
+        throw new Error((result && result.message) || this.data.t.renewRefreshFailed)
       }
 
       this.setData({
@@ -139,10 +165,10 @@ Page({
         renewCode: '',
         renewSn: ''
       })
-      utils.showNoActionModal('续借成功', '已成功续借图书')
+      utils.showNoActionModal(this.data.t.renewSuccessTitle, this.data.t.renewSuccessContent)
     }).catch((error) => {
       this.setData({
-        renewErrorMessage: error.message || '续借失败'
+        renewErrorMessage: error.message || this.data.t.renewFailed
       })
     })
   },
@@ -151,7 +177,7 @@ Page({
 
   onShareAppMessage: function() {
     return {
-      title: '图书馆',
+      title: this.data.t.shareTitle,
       path: '/pages/book/book'
     }
   }

--- a/pages/book/book.wxml
+++ b/pages/book/book.wxml
@@ -10,33 +10,33 @@
         <view class="weui-cells weui-cells_after-title">
           <view class="weui-cell weui-cell_input weui-cell_vcode">
             <view class="weui-cell__hd">
-              <view class="weui-label">图书馆密码</view>
+              <view class="weui-label">{{t.passwordLabel}}</view>
             </view>
             <view class="weui-cell__bd">
-              <input name="password" class="weui-input" password value="{{password}}" bindinput="onPasswordInput" placeholder="请输入图书馆密码" />
+              <input name="password" class="weui-input" password value="{{password}}" bindinput="onPasswordInput" placeholder="{{t.passwordPlaceholder}}" />
             </view>
           </view>
         </view>
       </view>
 
-      <view class="weui-cells__tips">我的借阅需要先输入图书馆密码查询，续借时会再次校验密码。</view>
+      <view class="weui-cells__tips">{{t.tip}}</view>
 
       <view class="btn-area">
-        <button type="primary" formType="submit" loading="{{loading}}" disabled="{{loading}}">{{hasQueriedBorrow ? '刷新借阅' : '查询借阅'}}</button>
+        <button type="primary" formType="submit" loading="{{loading}}" disabled="{{loading}}">{{hasQueriedBorrow ? t.refreshBorrow : t.queryBorrow}}</button>
       </view>
 
     </form>
 
     <view class="borrow-empty" wx:if="{{!hasQueriedBorrow && !loading}}">
-      输入图书馆密码后即可查看当前借阅记录。
+      {{t.emptyHint}}
     </view>
 
     <view class="borrow-empty" wx:elif="{{hasQueriedBorrow && (!result || result.length === 0)}}">
-      当前没有可展示的借阅记录。
+      {{t.emptyResult}}
     </view>
 
     <view block class="page__bd" wx:elif="{{result && result.length > 0}}">
-      <view class="weui-cells__title" style='margin-bottom:-10px'>借阅列表</view>
+      <view class="weui-cells__title" style='margin-bottom:-10px'>{{t.borrowListTitle}}</view>
       <block wx:for="{{result}}" wx:for-item="item" wx:key="item-key">
         <view class="weui-form-preview" style='margin-top:15px'>
           <view class="weui-form-preview__hd">
@@ -46,32 +46,32 @@
           </view>
           <view class="weui-form-preview__bd">
             <view class="weui-form-preview__item">
-              <view class="weui-form-preview__label">条形码</view>
+              <view class="weui-form-preview__label">{{t.barcode}}</view>
               <view class="weui-form-preview__value">{{item.id}}</view>
             </view>
             <view class="weui-form-preview__item">
-              <view class="weui-form-preview__label">SN号</view>
+              <view class="weui-form-preview__label">{{t.snNumber}}</view>
               <view class="weui-form-preview__value">{{item.sn}}</view>
             </view>
             <view class="weui-form-preview__item">
-              <view class="weui-form-preview__label">作者</view>
+              <view class="weui-form-preview__label">{{t.author}}</view>
               <view class="weui-form-preview__value">{{item.author}}</view>
             </view>
             <view class="weui-form-preview__item">
-              <view class="weui-form-preview__label">借阅时间</view>
+              <view class="weui-form-preview__label">{{t.borrowDate}}</view>
               <view class="weui-form-preview__value">{{item.borrowDate}}</view>
             </view>
             <view class="weui-form-preview__item">
-              <view class="weui-form-preview__label">应还时间</view>
+              <view class="weui-form-preview__label">{{t.returnDate}}</view>
               <view class="weui-form-preview__value">{{item.returnDate}}</view>
             </view>
             <view class="weui-form-preview__item">
-              <view class="weui-form-preview__label">续借次数</view>
+              <view class="weui-form-preview__label">{{t.renewCount}}</view>
               <view class="weui-form-preview__value">{{item.renewTime}}</view>
             </view>
           </view>
           <view class="weui-form-preview__ft">
-            <view data-code="{{item.code}}" data-sn="{{item.sn}}" bindtap="openRenewDialog" class="weui-form-preview__btn weui-form-preview__btn_primary" hover-class="weui-form-preview__btn_active">续借</view>
+            <view data-code="{{item.code}}" data-sn="{{item.sn}}" bindtap="openRenewDialog" class="weui-form-preview__btn weui-form-preview__btn_primary" hover-class="weui-form-preview__btn_active">{{t.renewButton}}</view>
           </view>
         </view>
       </block>
@@ -79,13 +79,13 @@
 
     <view wx:if="{{renewDialogVisible}}" class="renew-mask" bindtap="closeRenewDialog">
       <view class="renew-dialog" catchtap="noop">
-        <view class="renew-dialog__title">图书续借</view>
-        <view class="renew-dialog__message">请输入图书馆密码完成续借校验，密码只用于本次请求。</view>
-        <input class="renew-dialog__input" password value="{{renewPassword}}" bindinput="onRenewPasswordInput" placeholder="请输入图书馆密码" />
+        <view class="renew-dialog__title">{{t.renewDialogTitle}}</view>
+        <view class="renew-dialog__message">{{t.renewDialogMessage}}</view>
+        <input class="renew-dialog__input" password value="{{renewPassword}}" bindinput="onRenewPasswordInput" placeholder="{{t.passwordPlaceholder}}" />
         <view class="renew-dialog__error" wx:if="{{renewErrorMessage}}">{{renewErrorMessage}}</view>
         <view class="renew-dialog__actions">
-          <button class="renew-dialog__button renew-dialog__button_secondary" bindtap="closeRenewDialog" disabled="{{renewSubmitting}}">取消</button>
-          <button class="renew-dialog__button" type="primary" bindtap="confirmRenew" loading="{{renewSubmitting}}" disabled="{{renewSubmitting}}">确认续借</button>
+          <button class="renew-dialog__button renew-dialog__button_secondary" bindtap="closeRenewDialog" disabled="{{renewSubmitting}}">{{t.cancel}}</button>
+          <button class="renew-dialog__button" type="primary" bindtap="confirmRenew" loading="{{renewSubmitting}}" disabled="{{renewSubmitting}}">{{t.confirmRenew}}</button>
         </view>
       </view>
     </view>

--- a/pages/collectionDetail/collectionDetail.js
+++ b/pages/collectionDetail/collectionDetail.js
@@ -1,13 +1,44 @@
 const libraryApi = require('../../services/apis/library.js')
 const pageUtils = require('../../utils/page.js')
 var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
 
 Page({
   onShow: function () {
     themeUtil.applyTheme(this)
+    this.refreshI18n()
+  },
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        basicInfo: i18n.t('collectionDetailPage.basicInfo'),
+        bookName: i18n.t('collectionDetailPage.bookName'),
+        author: i18n.t('collectionDetailPage.author'),
+        heading: i18n.t('collectionDetailPage.heading'),
+        responsible: i18n.t('collectionDetailPage.responsible'),
+        headingResponsible: i18n.t('collectionDetailPage.headingResponsible'),
+        publisher: i18n.t('collectionDetailPage.publisher'),
+        publishYear: i18n.t('collectionDetailPage.publishYear'),
+        publisherYear: i18n.t('collectionDetailPage.publisherYear'),
+        isbn: i18n.t('collectionDetailPage.isbn'),
+        fixedPrice: i18n.t('collectionDetailPage.fixedPrice'),
+        isbnPrice: i18n.t('collectionDetailPage.isbnPrice'),
+        physicalDesc: i18n.t('collectionDetailPage.physicalDesc'),
+        personalResp: i18n.t('collectionDetailPage.personalResp'),
+        subjectTheme: i18n.t('collectionDetailPage.subjectTheme'),
+        clcNumber: i18n.t('collectionDetailPage.clcNumber'),
+        collectionInfo: i18n.t('collectionDetailPage.collectionInfo'),
+        location: i18n.t('collectionDetailPage.location'),
+        callNumber: i18n.t('collectionDetailPage.callNumber'),
+        barcodeNumber: i18n.t('collectionDetailPage.barcodeNumber'),
+        status: i18n.t('collectionDetailPage.status'),
+        shareTitle: i18n.t('collectionDetailPage.shareTitle')
+      }
+    })
   },
   data: {
     themeClass: '',
+    t: {},
     query: null,
     result: null,
     errorMessage: null
@@ -59,7 +90,7 @@ Page({
 
   onShareAppMessage: function() {
     return {
-      title: '馆藏详情',
+      title: this.data.t.shareTitle,
       path: '/pages/collection/collection'
     }
   }

--- a/pages/collectionDetail/collectionDetail.wxml
+++ b/pages/collectionDetail/collectionDetail.wxml
@@ -3,100 +3,100 @@
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="container" wx:if="{{result}}">
-    <view class="weui-cells__title">基本信息</view>
+    <view class="weui-cells__title">{{t.basicInfo}}</view>
     <view class="weui-cells weui-cells_after-title">
       <view wx:if="{{result.bookname && result.bookname.length!=0}}" class="weui-cell">
-        <view class="weui-cell__bd">书名</view>
+        <view class="weui-cell__bd">{{t.bookName}}</view>
         <view class="weui-cell__ft">{{result.bookname}}</view>
       </view>
       <view wx:if="{{result.author && result.author.length!=0}}" class="weui-cell">
-        <view class="weui-cell__bd">作者</view>
+        <view class="weui-cell__bd">{{t.author}}</view>
         <view class="weui-cell__ft">{{result.author}}</view>
       </view>
       <block wx:if="{{result.principal && result.principal.length!=0 && result.principal.split(' ').length!=1}}">
         <view class="weui-cell">
-          <view class="weui-cell__bd">题名</view>
+          <view class="weui-cell__bd">{{t.heading}}</view>
           <view class="weui-cell__ft">{{result.autograph}}</view>
         </view>
         <view class="weui-cell">
-          <view class="weui-cell__bd">负责者</view>
+          <view class="weui-cell__bd">{{t.responsible}}</view>
           <view class="weui-cell__ft">{{result.director}}</view>
         </view>
       </block>
       <view wx:if="{{result.principal && result.principal.length!=0 && result.principal.split(' ').length==1}}">
         <view class="weui-cell">
-          <view class="weui-cell__bd">题名/负责者</view>
+          <view class="weui-cell__bd">{{t.headingResponsible}}</view>
           <view class="weui-cell__ft">{{result.principal}}</view>
         </view>
       </view>
       <block wx:if="{{result.publishingHouse && result.publishingHouse.length!=0 && result.publishingHouse.split(' ').length!=1}}">
         <view class="weui-cell">
-          <view class="weui-cell__bd">出版社</view>
+          <view class="weui-cell__bd">{{t.publisher}}</view>
           <view class="weui-cell__ft">{{result.house}}</view>
         </view>
         <view class="weui-cell">
-          <view class="weui-cell__bd">出版年</view>
+          <view class="weui-cell__bd">{{t.publishYear}}</view>
           <view class="weui-cell__ft">{{result.year}}</view>
         </view>
       </block>
       <view wx:if="{{result.publishingHouse && result.publishingHouse.length!=0 && result.publishingHouse.split(' ').length==1}}">
         <view class="weui-cell">
-          <view class="weui-cell__bd">出版社/出版年</view>
+          <view class="weui-cell__bd">{{t.publisherYear}}</view>
           <view class="weui-cell__ft">{{result.publishingHouse}}</view>
         </view>
       </view>
       <block wx:if="{{result.price && result.price.length!=0 && result.price.split(' ').length!=1}}">
         <view class="weui-cell">
-          <view class="weui-cell__bd">ISBN</view>
+          <view class="weui-cell__bd">{{t.isbn}}</view>
           <view class="weui-cell__ft">{{result.ISBN}}</view>
         </view>
         <view class="weui-cell">
-          <view class="weui-cell__bd">定价</view>
+          <view class="weui-cell__bd">{{t.fixedPrice}}</view>
           <view class="weui-cell__ft">{{result.priceValue}}</view>
         </view>
       </block>
       <view wx:if="{{result.price && result.price.length!=0 && result.price.split(' ').length==1}}">
         <view class="weui-cell">
-          <view class="weui-cell__bd">ISBN/定价</view>
+          <view class="weui-cell__bd">{{t.isbnPrice}}</view>
           <view class="weui-cell__ft">{{result.price}}</view>
         </view>
       </view>
       <view wx:if="{{result.physicalDescriptionArea && result.physicalDescriptionArea.length!=0}}" class="weui-cell">
-        <view class="weui-cell__bd">载体形态项</view>
+        <view class="weui-cell__bd">{{t.physicalDesc}}</view>
         <view class="weui-cell__ft">{{result.physicalDescriptionArea}}</view>
       </view>
 
       <view wx:if="{{result.personalPrincipal && result.personalPrincipal.length!=0}}" class="weui-cell">
-        <view class="weui-cell__bd">个人责任者</view>
+        <view class="weui-cell__bd">{{t.personalResp}}</view>
         <view class="weui-cell__ft">{{result.personalPrincipal}}</view>
       </view>
       <view wx:if="{{result.subjectTheme && result.subjectTheme.length!=0}}" class="weui-cell">
-        <view class="weui-cell__bd">学科主题</view>
+        <view class="weui-cell__bd">{{t.subjectTheme}}</view>
         <view class="weui-cell__ft">{{result.subjectTheme}}</view>
       </view>
       <view wx:if="{{result.chineseLibraryClassification && result.chineseLibraryClassification.length!=0}}" class="weui-cell">
-        <view class="weui-cell__bd">中图法分类号</view>
+        <view class="weui-cell__bd">{{t.clcNumber}}</view>
         <view class="weui-cell__ft">{{result.chineseLibraryClassification}}</view>
       </view>
     </view>
 
-    <view class="weui-cells__title">馆藏信息</view>
+    <view class="weui-cells__title">{{t.collectionInfo}}</view>
     <view block wx:for="{{result.collectionDistributionList}}" wx:for-item="i" wx:key="collectionDistributionList">
       <view style='margin-bottom:25rpx' class="weui-cells weui-cells_after-title">
         <view class="weui-cell">
-          <view class="weui-cell__bd">馆藏地</view>
+          <view class="weui-cell__bd">{{t.location}}</view>
           <view class="weui-cell__ft">{{i.location}}</view>
         </view>
         <view class="weui-cell">
-          <view class="weui-cell__bd">索取号</view>
+          <view class="weui-cell__bd">{{t.callNumber}}</view>
           <view class="weui-cell__ft">{{i.callNumber}}</view>
         </view>
         <view class="weui-cell">
-          <view class="weui-cell__bd">条码号</view>
+          <view class="weui-cell__bd">{{t.barcodeNumber}}</view>
           <view class="weui-cell__ft">{{i.barcode}}</view>
         </view>
         <view class="weui-cell">
-          <view class="weui-cell__bd">状态</view>
+          <view class="weui-cell__bd">{{t.status}}</view>
           <view class="weui-cell__ft">{{i.state}}</view>
         </view>
       </view>

--- a/pages/communityCenter/communityCenter.js
+++ b/pages/communityCenter/communityCenter.js
@@ -50,6 +50,10 @@ Page({
     summaryProfile: null,
     hasShownOnce: false,
     loading: true,
+    loadingMore: false,
+    hasMore: true,
+    pageStart: 0,
+    pageSize: 20,
     errorMessage: null,
     t: {}
   },
@@ -101,31 +105,79 @@ Page({
   },
 
   loadCenter: function() {
+    var self = this
+    self.setData({ pageStart: 0, hasMore: true })
+
     return pageUtils.runWithNavigationLoading(this, () => {
       return Promise.all([
-        communityApi.getCenter(this.data.moduleId),
+        communityApi.getCenter(this.data.moduleId, { start: 0, size: this.data.pageSize }),
         this.loadSummaryProfile()
       ])
     }).then((resultList) => {
       const result = resultList[0]
       if (!result.success) {
-        pageUtils.showTopTips(this, result.message || i18n.t('common.loadFailed'))
+        pageUtils.showTopTips(self, result.message || i18n.t('common.loadFailed'))
         return
       }
 
-      const itemsByTab = this.normalizeCenterData(this.data.moduleId, result.data || [])
-      const defaultTab = this.data.tabs.length ? this.data.tabs[0].key : 'default'
-      this.setData({
+      var items = result.data || []
+      const itemsByTab = self.normalizeCenterData(self.data.moduleId, items)
+      const defaultTab = self.data.tabs.length ? self.data.tabs[0].key : 'default'
+      self.setData({
         itemsByTab: itemsByTab,
-        loading: false
+        loading: false,
+        pageStart: items.length,
+        hasMore: items.length >= self.data.pageSize
       })
-      this.setActiveTab(this.data.activeTabKey || defaultTab)
+      self.setActiveTab(self.data.activeTabKey || defaultTab)
     }).catch((error) => {
-      this.setData({
+      self.setData({
         loading: false
       })
-      pageUtils.showTopTips(this, error.message)
+      pageUtils.showTopTips(self, error.message)
     })
+  },
+
+  loadMoreCenter: function() {
+    var self = this
+    if (self.data.loadingMore || !self.data.hasMore) return
+
+    self.setData({ loadingMore: true })
+
+    communityApi.getCenter(self.data.moduleId, { start: self.data.pageStart, size: self.data.pageSize })
+      .then(function(result) {
+        if (!result.success) {
+          pageUtils.showTopTips(self, result.message || i18n.t('common.loadFailed'))
+          self.setData({ loadingMore: false })
+          return
+        }
+
+        var newItems = result.data || []
+        var normalized = self.normalizeCenterData(self.data.moduleId, newItems)
+        var currentItems = self.data.itemsByTab || {}
+        var mergedItems = {}
+
+        Object.keys(normalized).forEach(function(tabKey) {
+          mergedItems[tabKey] = (currentItems[tabKey] || []).concat(normalized[tabKey] || [])
+        })
+        Object.keys(currentItems).forEach(function(tabKey) {
+          if (!mergedItems[tabKey]) {
+            mergedItems[tabKey] = currentItems[tabKey]
+          }
+        })
+
+        self.setData({
+          itemsByTab: mergedItems,
+          loadingMore: false,
+          pageStart: self.data.pageStart + newItems.length,
+          hasMore: newItems.length >= self.data.pageSize
+        })
+        self.setActiveTab(self.data.activeTabKey)
+      })
+      .catch(function(error) {
+        self.setData({ loadingMore: false })
+        pageUtils.showTopTips(self, error.message)
+      })
   },
 
   switchTab: function(event) {

--- a/pages/communityCenter/communityCenter.wxml
+++ b/pages/communityCenter/communityCenter.wxml
@@ -87,6 +87,17 @@
         </view>
       </view>
     </block>
+
+    <view class="load_more_box" wx:if="{{hasMore}}" bindtap="loadMoreCenter">
+      <text wx:if="{{!loadingMore}}">加载更多</text>
+      <view wx:else class="load_more_loading">
+        <i class="weui-loading"></i>
+        <text>加载中...</text>
+      </view>
+    </view>
+    <view class="load_more_box" wx:if="{{!hasMore && activeItems.length > 0}}">
+      <text class="load_more_end">没有更多了</text>
+    </view>
   </view>
 
   <view class="bottom_bar" wx:if="{{moduleConfig}}">

--- a/pages/communityCenter/communityCenter.wxss
+++ b/pages/communityCenter/communityCenter.wxss
@@ -204,3 +204,20 @@
   font-size: 24rpx;
   line-height: 1.7;
 }
+
+.load_more_box {
+  padding: 30rpx 0;
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-size: 26rpx;
+}
+
+.load_more_loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 10rpx;
+}
+
+.load_more_end {
+  color: var(--color-text-tertiary);
+}

--- a/pages/data/data.js
+++ b/pages/data/data.js
@@ -9,7 +9,11 @@ Page({
   refreshI18n: function () {
     this.setData({
       t: {
-        navTitle: i18n.t('dataPage.navTitle')
+        navTitle: i18n.t('dataPage.navTitle'),
+        selectProject: i18n.t('dataPage.selectProject'),
+        electricityQuery: i18n.t('dataPage.electricityQuery'),
+        yellowPageQuery: i18n.t('dataPage.yellowPageQuery'),
+        shareTitle: i18n.t('dataPage.shareTitle')
       }
     })
     wx.setNavigationBarTitle({ title: this.data.t.navTitle })
@@ -19,7 +23,7 @@ Page({
   },
   onShareAppMessage: function() {
     return {
-      title: '数据查询',
+      title: this.data.t.shareTitle,
       path: '/pages/data/data'
     }
   }

--- a/pages/data/data.wxml
+++ b/pages/data/data.wxml
@@ -1,12 +1,12 @@
 <view class="page__bd {{themeClass}}" style="{{fontStyle}}">
-  <view class="weui-cells__title">选择查询项目</view>
+  <view class="weui-cells__title">{{t.selectProject}}</view>
   <view class="weui-cells weui-cells_after-title">
     <navigator url="/pages/electricity/electricity" class="weui-cell weui-cell_access" hover-class="weui-cell_active">
-      <view class="weui-cell__bd">电费查询</view>
+      <view class="weui-cell__bd">{{t.electricityQuery}}</view>
       <view class="weui-cell__ft weui-cell__ft_in-access"></view>
     </navigator>
     <navigator url="/pages/yellowPage/yellowPage" class="weui-cell weui-cell_access" hover-class="weui-cell_active">
-      <view class="weui-cell__bd">黄页查询</view>
+      <view class="weui-cell__bd">{{t.yellowPageQuery}}</view>
       <view class="weui-cell__ft weui-cell__ft_in-access"></view>
     </navigator>
   </view>

--- a/pages/electricity/electricity.js
+++ b/pages/electricity/electricity.js
@@ -20,7 +20,28 @@ Page({
   refreshI18n: function () {
     this.setData({
       t: {
-        navTitle: i18n.t('electricityPage.navTitle')
+        navTitle: i18n.t('electricityPage.navTitle'),
+        queryInfo: i18n.t('electricityPage.queryInfo'),
+        yearLabel: i18n.t('electricityPage.yearLabel'),
+        nameLabel: i18n.t('electricityPage.nameLabel'),
+        namePlaceholder: i18n.t('electricityPage.namePlaceholder'),
+        studentIdLabel: i18n.t('electricityPage.studentIdLabel'),
+        studentIdPlaceholder: i18n.t('electricityPage.studentIdPlaceholder'),
+        fillAllFields: i18n.t('electricityPage.fillAllFields'),
+        invalidStudentId: i18n.t('electricityPage.invalidStudentId'),
+        queryButton: i18n.t('electricityPage.queryButton'),
+        resultTitle: i18n.t('electricityPage.resultTitle'),
+        dormitory: i18n.t('electricityPage.dormitory'),
+        occupants: i18n.t('electricityPage.occupants'),
+        department: i18n.t('electricityPage.department'),
+        usedAmount: i18n.t('electricityPage.usedAmount'),
+        freeAmount: i18n.t('electricityPage.freeAmount'),
+        chargedAmount: i18n.t('electricityPage.chargedAmount'),
+        price: i18n.t('electricityPage.price'),
+        totalBill: i18n.t('electricityPage.totalBill'),
+        averageBill: i18n.t('electricityPage.averageBill'),
+        reQuery: i18n.t('electricityPage.reQuery'),
+        shareTitle: i18n.t('electricityPage.shareTitle')
       }
     })
     wx.setNavigationBarTitle({ title: this.data.t.navTitle })
@@ -58,12 +79,12 @@ Page({
     }
 
     if (!payload.name || !payload.number) {
-      pageUtils.showTopTips(this, '请完整填写姓名和学号')
+      pageUtils.showTopTips(this, this.data.t.fillAllFields)
       return
     }
 
     if (!/^\d{8,12}$/.test(payload.number)) {
-      pageUtils.showTopTips(this, '请输入正确的学号')
+      pageUtils.showTopTips(this, this.data.t.invalidStudentId)
       return
     }
 
@@ -88,7 +109,7 @@ Page({
 
   onShareAppMessage: function() {
     return {
-      title: '电费查询',
+      title: this.data.t.shareTitle,
       path: '/pages/electricity/electricity'
     }
   }

--- a/pages/electricity/electricity.wxml
+++ b/pages/electricity/electricity.wxml
@@ -2,11 +2,11 @@
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
   <view class="container" wx:if="{{!result}}">
-    <view class="weui-cells__title">查询信息</view>
+    <view class="weui-cells__title">{{t.queryInfo}}</view>
     <view class="weui-cells weui-cells_after-title">
       <view class="weui-cell">
         <view class="weui-cell__hd">
-          <view class="weui-label">年份</view>
+          <view class="weui-label">{{t.yearLabel}}</view>
         </view>
         <view class="weui-cell__bd">
           <picker range="{{yearOptions}}" value="{{yearIndex}}" bindchange="handlePickerChange">
@@ -16,74 +16,74 @@
       </view>
       <view class="weui-cell weui-cell_input">
         <view class="weui-cell__hd">
-          <view class="weui-label">姓名</view>
+          <view class="weui-label">{{t.nameLabel}}</view>
         </view>
         <view class="weui-cell__bd">
-          <input value="{{name}}" data-field="name" bindinput="setFieldValue" class="weui-input" placeholder="请输入姓名" />
+          <input value="{{name}}" data-field="name" bindinput="setFieldValue" class="weui-input" placeholder="{{t.namePlaceholder}}" />
         </view>
       </view>
       <view class="weui-cell weui-cell_input">
         <view class="weui-cell__hd">
-          <view class="weui-label">学号</view>
+          <view class="weui-label">{{t.studentIdLabel}}</view>
         </view>
         <view class="weui-cell__bd">
-          <input value="{{number}}" data-field="number" bindinput="setFieldValue" class="weui-input" placeholder="请输入学号" />
+          <input value="{{number}}" data-field="number" bindinput="setFieldValue" class="weui-input" placeholder="{{t.studentIdPlaceholder}}" />
         </view>
       </view>
     </view>
 
     <view class="btn-area">
-      <button type="primary" disabled="{{loading}}" bindtap="submitQuery">查询</button>
+      <button type="primary" disabled="{{loading}}" bindtap="submitQuery">{{t.queryButton}}</button>
     </view>
   </view>
 
   <view class="container" wx:if="{{result}}">
-    <view class="weui-cells__title">电费信息</view>
+    <view class="weui-cells__title">{{t.resultTitle}}</view>
     <view class="weui-cells weui-cells_after-title">
       <view class="weui-cell">
-        <view class="weui-cell__bd">年份</view>
+        <view class="weui-cell__bd">{{t.yearLabel}}</view>
         <view class="weui-cell__ft">{{result.year}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">宿舍</view>
+        <view class="weui-cell__bd">{{t.dormitory}}</view>
         <view class="weui-cell__ft">{{result.buildingNumber}}{{result.roomNumber}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">入住人数</view>
+        <view class="weui-cell__bd">{{t.occupants}}</view>
         <view class="weui-cell__ft">{{result.peopleNumber}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">学院</view>
+        <view class="weui-cell__bd">{{t.department}}</view>
         <view class="weui-cell__ft">{{result.department}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">用电数额</view>
+        <view class="weui-cell__bd">{{t.usedAmount}}</view>
         <view class="weui-cell__ft">{{result.usedElectricAmount}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">免费电额</view>
+        <view class="weui-cell__bd">{{t.freeAmount}}</view>
         <view class="weui-cell__ft">{{result.freeElectricAmount}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">计费电数</view>
+        <view class="weui-cell__bd">{{t.chargedAmount}}</view>
         <view class="weui-cell__ft">{{result.feeBasedElectricAmount}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">电价</view>
+        <view class="weui-cell__bd">{{t.price}}</view>
         <view class="weui-cell__ft">{{result.electricPrice}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">总电费</view>
+        <view class="weui-cell__bd">{{t.totalBill}}</view>
         <view class="weui-cell__ft">{{result.totalElectricBill}}</view>
       </view>
       <view class="weui-cell">
-        <view class="weui-cell__bd">平均电费</view>
+        <view class="weui-cell__bd">{{t.averageBill}}</view>
         <view class="weui-cell__ft">{{result.averageElectricBill}}</view>
       </view>
     </view>
 
     <view class="btn-area">
-      <button type="primary" bindtap="resetQuery">重新查询</button>
+      <button type="primary" bindtap="resetQuery">{{t.reQuery}}</button>
     </view>
   </view>
 </view>

--- a/pages/newsDetail/newsDetail.js
+++ b/pages/newsDetail/newsDetail.js
@@ -3,13 +3,33 @@ const infoApi = require('../../services/apis/info.js')
 const messagesApi = require('../../services/apis/messages.js')
 const pageUtils = require('../../utils/page.js')
 var themeUtil = require('../../utils/theme')
+var i18n = require('../../utils/i18n')
 
 Page({
   onShow: function () {
     themeUtil.applyTheme(this)
+    this.refreshI18n()
+  },
+  refreshI18n: function () {
+    this.setData({
+      t: {
+        loadingDetail: i18n.t('newsDetailPage.loadingDetail'),
+        loadFailed: i18n.t('newsDetailPage.loadFailed'),
+        noContent: i18n.t('newsDetailPage.noContent'),
+        announcement: i18n.t('newsDetailPage.announcement'),
+        news: i18n.t('newsDetailPage.news')
+      }
+    })
+    // Re-set navigation bar title based on mode
+    if (this.data.mode === 'announcement') {
+      wx.setNavigationBarTitle({ title: this.data.t.announcement })
+    } else {
+      wx.setNavigationBarTitle({ title: this.data.t.news })
+    }
   },
   data: {
     themeClass: '',
+    t: {},
     newsItem: null,
     loading: false,
     errorMessage: null,
@@ -29,7 +49,7 @@ Page({
       loadingKey: 'loading'
     }).then((result) => {
       if (!result.success) {
-        throw new Error(result.message || '加载详情失败')
+        throw new Error(result.message || this.data.t.loadFailed)
       }
 
       const payload = result.data || {}
@@ -37,14 +57,14 @@ Page({
       this.setData({
         newsItem: Object.assign({}, currentItem, payload, {
           publishDate: payload.publishDate || payload.publishTime || currentItem.publishDate || '',
-          navigationTitle: mode === 'announcement' ? '系统公告' : '新闻'
+          navigationTitle: mode === 'announcement' ? this.data.t.announcement : this.data.t.news
         }),
         errorMessage: null
       })
     }).catch((error) => {
-      pageUtils.showTopTips(this, error.message || '加载详情失败')
+      pageUtils.showTopTips(this, error.message || this.data.t.loadFailed)
       this.setData({
-        errorMessage: error.message || '加载详情失败'
+        errorMessage: error.message || this.data.t.loadFailed
       })
     })
   },
@@ -59,7 +79,7 @@ Page({
     })
 
     wx.setNavigationBarTitle({
-      title: mode === 'announcement' ? '系统公告' : '新闻'
+      title: mode === 'announcement' ? this.data.t.announcement : this.data.t.news
     })
 
     this.loadDetail(detailId || (newsItem && newsItem.id) || '', mode)
@@ -68,8 +88,8 @@ Page({
   onShareAppMessage: function() {
     const navigationTitle = this.data.newsItem && this.data.newsItem.navigationTitle
     return {
-      title: this.data.newsItem && this.data.newsItem.title ? this.data.newsItem.title : '新闻',
-      path: navigationTitle === '系统公告' ? '/pages/inbox/inbox' : '/pages/news/news'
+      title: this.data.newsItem && this.data.newsItem.title ? this.data.newsItem.title : this.data.t.news,
+      path: navigationTitle === this.data.t.announcement ? '/pages/inbox/inbox' : '/pages/news/news'
     }
   }
 })

--- a/pages/newsDetail/newsDetail.wxml
+++ b/pages/newsDetail/newsDetail.wxml
@@ -2,11 +2,11 @@
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
   <view class="container detail-loading" wx:if="{{loading && !newsItem}}">
     <i class="weui-loading"></i>
-    <view>正在加载详情</view>
+    <view>{{t.loadingDetail}}</view>
   </view>
   <view class="container" wx:if="{{newsItem}}">
     <view class="detail_title">{{newsItem.title}}</view>
     <view class="detail_date">{{newsItem.publishDate || newsItem.publishTime}}</view>
-    <view class="detail_content">{{newsItem.content || '暂无详细内容'}}</view>
+    <view class="detail_content">{{newsItem.content || t.noContent}}</view>
   </view>
 </view>

--- a/pages/yellowPage/yellowPage.js
+++ b/pages/yellowPage/yellowPage.js
@@ -28,7 +28,8 @@ Page({
   refreshI18n: function () {
     this.setData({
       t: {
-        navTitle: i18n.t('yellowPagePage.navTitle')
+        navTitle: i18n.t('yellowPagePage.navTitle'),
+        shareTitle: i18n.t('yellowPagePage.shareTitle')
       }
     })
     wx.setNavigationBarTitle({ title: this.data.t.navTitle })
@@ -74,7 +75,7 @@ Page({
 
   onShareAppMessage: function() {
     return {
-      title: '黄页查询',
+      title: this.data.t.shareTitle,
       path: '/pages/yellowPage/yellowPage'
     }
   }

--- a/services/auth.js
+++ b/services/auth.js
@@ -4,6 +4,7 @@ const endpoints = require('./endpoints.js')
 const dataSource = require('./data-source.js')
 const mock = require('../mock/index.js')
 const { normalizePayload } = require('./response.js')
+const { generateRequestId } = require('./request-id.js')
 let reLaunching = false
 const SESSION_STORAGE_KEYS = [storageKeys.sessionToken, storageKeys.username, 'accessToken', 'refreshToken']
 
@@ -73,16 +74,23 @@ function logout() {
     return mock.handleLogout(token)
   }
 
+  var requestId = generateRequestId()
+  var startTime = Date.now()
+
   return new Promise((resolve) => {
     wx.request({
       url: config.resourceDomain + endpoints.auth.logout,
       method: 'POST',
       header: {
         Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-Request-ID': requestId
       },
       timeout: config.requestTimeout,
-      complete: function() {
+      complete: function(res) {
+        var elapsed = Date.now() - startTime
+        var status = (res && res.statusCode) || 'FAILED'
+        console.debug('rid:' + requestId + ' | POST ' + endpoints.auth.logout + ' | ' + status + ' | ' + elapsed + 'ms')
         resolve()
       }
     })
@@ -99,15 +107,22 @@ function validateSessionToken() {
     return Promise.resolve(mock.isSessionTokenValid(token))
   }
 
+  var requestId = generateRequestId()
+  var startTime = Date.now()
+
   return new Promise((resolve) => {
     wx.request({
-      url: config.resourceDomain + endpoints.user.profile,
+      url: config.resourceDomain + endpoints.auth.validate,
       method: 'GET',
       header: {
-        Authorization: `Bearer ${token}`
+        Authorization: `Bearer ${token}`,
+        'X-Request-ID': requestId
       },
       timeout: config.requestTimeout,
       success: function(result) {
+        var elapsed = Date.now() - startTime
+        console.debug('rid:' + requestId + ' | GET ' + endpoints.auth.validate + ' | ' + result.statusCode + ' | ' + elapsed + 'ms')
+
         if (result.statusCode === 200) {
           const payload = normalizePayload(result.data)
           resolve(!!payload.success)
@@ -117,6 +132,8 @@ function validateSessionToken() {
         resolve(false)
       },
       fail: function() {
+        var elapsed = Date.now() - startTime
+        console.debug('rid:' + requestId + ' | GET ' + endpoints.auth.validate + ' | FAILED | ' + elapsed + 'ms')
         resolve(false)
       }
     })

--- a/services/community/module-handlers/secret.js
+++ b/services/community/module-handlers/secret.js
@@ -42,9 +42,13 @@ module.exports = {
   },
 
   // --- Center ---
-  getCenter: function() {
+  getCenter: function(options) {
+    var config = options || {}
+    var start = Number(config.start || 0)
+    var size = Number(config.size || 20)
+
     return request({
-      url: endpoints.community.secret.profile,
+      url: endpoints.community.secret.profilePaged(start, size),
       method: 'GET',
       authRequired: true
     })

--- a/services/endpoints.js
+++ b/services/endpoints.js
@@ -1,7 +1,8 @@
 module.exports = {
   auth: {
     login: '/api/auth/login',
-    logout: '/api/auth/logout'
+    logout: '/api/auth/logout',
+    validate: '/api/auth/validate'
   },
   user: {
     avatar: '/api/profile/avatar',

--- a/services/request-id.js
+++ b/services/request-id.js
@@ -1,0 +1,9 @@
+function generateRequestId() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    const r = Math.random() * 16 | 0
+    const v = c === 'x' ? r : (r & 0x3 | 0x8)
+    return v.toString(16)
+  })
+}
+
+module.exports = { generateRequestId }

--- a/services/request.js
+++ b/services/request.js
@@ -3,6 +3,7 @@ const auth = require('./auth.js')
 const dataSource = require('./data-source.js')
 const mock = require('../mock/index.js')
 const { normalizePayload, pickMessage } = require('./response.js')
+const { generateRequestId } = require('./request-id.js')
 
 const DEVICE_ID_STORAGE_KEY = '__gdei_device_id'
 
@@ -49,6 +50,7 @@ function request(options) {
     const app = getApp()
     header['Accept-Language'] = (app && app.globalData && app.globalData.locale) || 'zh-CN'
     header['X-Device-ID'] = getDeviceId()
+    header['X-Request-ID'] = options.requestId || generateRequestId()
 
     if (showLoading) {
       wx.showNavigationBarLoading()
@@ -77,6 +79,9 @@ function request(options) {
       reject(new Error(error && error.message ? error.message : '服务暂不可用，请稍后再试'))
     }
 
+    const requestId = header['X-Request-ID']
+    const startTime = Date.now()
+
     if (dataSource.isMockMode()) {
       mock.handleRequest({
         url,
@@ -96,6 +101,9 @@ function request(options) {
       timeout: config.requestTimeout,
       data,
       success: function(res) {
+        var elapsed = Date.now() - startTime
+        console.debug('rid:' + requestId + ' | ' + method + ' ' + url + ' | ' + res.statusCode + ' | ' + elapsed + 'ms')
+
         if (res.statusCode === 200) {
           resolvePayload(res.data)
         } else if (res.statusCode === 401) {
@@ -107,6 +115,8 @@ function request(options) {
         }
       },
       fail: function() {
+        var elapsed = Date.now() - startTime
+        console.debug('rid:' + requestId + ' | ' + method + ' ' + url + ' | FAILED | ' + elapsed + 'ms')
         reject(new Error('网络连接超时，请重试'))
       },
       complete: finishLoading
@@ -121,5 +131,6 @@ function request(options) {
 }
 
 module.exports = {
-  request
+  request,
+  generateRequestId
 }

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,294 @@
+const path = require('node:path')
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { clearModule, stubModule } = require('./helpers/module.js')
+
+const ROOT = path.resolve(__dirname, '..')
+const AUTH_MODULE = path.join(ROOT, 'services/auth.js')
+const CONFIG_MODULE = path.join(ROOT, 'config/index.js')
+const ENDPOINTS_MODULE = path.join(ROOT, 'services/endpoints.js')
+const DATA_SOURCE_MODULE = path.join(ROOT, 'services/data-source.js')
+const MOCK_MODULE = path.join(ROOT, 'mock/index.js')
+const RESPONSE_MODULE = path.join(ROOT, 'services/response.js')
+
+function setup(wxOverrides) {
+  const storage = {}
+  global.wx = {
+    getStorageSync: function(key) { return storage[key] || '' },
+    setStorageSync: function(key, val) { storage[key] = val },
+    removeStorageSync: function(key) { delete storage[key] },
+    showModal: function(opts) { if (opts.success) opts.success({ confirm: true }) },
+    reLaunch: function() {},
+    request: function() {},
+    ...wxOverrides
+  }
+
+  stubModule(CONFIG_MODULE, {
+    resourceDomain: 'https://test.example.com/',
+    requestTimeout: 5000,
+    currentEnv: 'prod'
+  })
+  stubModule(ENDPOINTS_MODULE, {
+    auth: { login: '/api/auth/login', logout: '/api/auth/logout', validate: '/api/auth/validate' },
+    user: { profile: '/api/user/profile' }
+  })
+  stubModule(DATA_SOURCE_MODULE, {
+    isMockMode: function() { return false }
+  })
+  stubModule(MOCK_MODULE, {
+    isSessionTokenValid: function() { return false },
+    handleLogout: function() { return Promise.resolve() }
+  })
+
+  clearModule(AUTH_MODULE)
+  return { auth: require(AUTH_MODULE), storage }
+}
+
+// ---- getSessionToken / setSessionToken ----
+
+test('getSessionToken returns empty string when no token stored', function() {
+  const { auth } = setup()
+  assert.equal(auth.getSessionToken(), '')
+})
+
+test('setSessionToken persists and getSessionToken retrieves', function() {
+  const { auth } = setup()
+  auth.setSessionToken('jwt-abc-123')
+  assert.equal(auth.getSessionToken(), 'jwt-abc-123')
+})
+
+// ---- clearSession ----
+
+test('clearSession removes all session-related storage keys', function() {
+  const { auth, storage } = setup()
+  // Pre-populate storage
+  global.wx.setStorageSync('sessionToken', 'tok')
+  global.wx.setStorageSync('username', 'user1')
+  global.wx.setStorageSync('accessToken', 'at')
+  global.wx.setStorageSync('refreshToken', 'rt')
+
+  auth.clearSession()
+
+  assert.equal(global.wx.getStorageSync('sessionToken'), '')
+  assert.equal(global.wx.getStorageSync('username'), '')
+  assert.equal(global.wx.getStorageSync('accessToken'), '')
+  assert.equal(global.wx.getStorageSync('refreshToken'), '')
+})
+
+// ---- ensureSessionToken ----
+
+test('ensureSessionToken resolves with token when present', async function() {
+  const { auth } = setup()
+  auth.setSessionToken('valid-token')
+
+  const token = await auth.ensureSessionToken()
+  assert.equal(token, 'valid-token')
+})
+
+test('ensureSessionToken rejects when no token and interactive', async function() {
+  const { auth } = setup()
+
+  await assert.rejects(
+    auth.ensureSessionToken(),
+    { message: '未检测到登录凭证' }
+  )
+})
+
+test('ensureSessionToken rejects without modal when non-interactive', async function() {
+  let modalShown = false
+  const { auth } = setup({
+    getStorageSync: function() { return '' },
+    setStorageSync: function() {},
+    removeStorageSync: function() {},
+    showModal: function() { modalShown = true },
+    reLaunch: function() {},
+    request: function() {}
+  })
+
+  await assert.rejects(
+    auth.ensureSessionToken({ interactive: false }),
+    { message: '未检测到登录凭证' }
+  )
+  assert.ok(!modalShown, 'should not show modal in non-interactive mode')
+})
+
+// ---- validateSessionToken ----
+
+test('validateSessionToken resolves false when no token stored', async function() {
+  const { auth } = setup()
+
+  const result = await auth.validateSessionToken()
+  assert.equal(result, false)
+})
+
+test('validateSessionToken resolves true on 200 success response', async function() {
+  const { auth } = setup({
+    getStorageSync: function(key) {
+      if (key === 'sessionToken') return 'valid-jwt'
+      return ''
+    },
+    setStorageSync: function() {},
+    removeStorageSync: function() {},
+    showModal: function() {},
+    reLaunch: function() {},
+    request: function(opts) {
+      opts.success({
+        statusCode: 200,
+        data: { code: 200, success: true, message: 'success', data: null }
+      })
+    }
+  })
+
+  const result = await auth.validateSessionToken()
+  assert.equal(result, true)
+})
+
+test('validateSessionToken resolves false on 401', async function() {
+  const { auth } = setup({
+    getStorageSync: function(key) {
+      if (key === 'sessionToken') return 'expired-jwt'
+      return ''
+    },
+    setStorageSync: function() {},
+    removeStorageSync: function() {},
+    showModal: function() {},
+    reLaunch: function() {},
+    request: function(opts) {
+      opts.success({ statusCode: 401, data: {} })
+    }
+  })
+
+  const result = await auth.validateSessionToken()
+  assert.equal(result, false)
+})
+
+test('validateSessionToken resolves false on network failure', async function() {
+  const { auth } = setup({
+    getStorageSync: function(key) {
+      if (key === 'sessionToken') return 'some-jwt'
+      return ''
+    },
+    setStorageSync: function() {},
+    removeStorageSync: function() {},
+    showModal: function() {},
+    reLaunch: function() {},
+    request: function(opts) {
+      opts.fail()
+    }
+  })
+
+  const result = await auth.validateSessionToken()
+  assert.equal(result, false)
+})
+
+// ---- validateSessionToken uses correct endpoint ----
+
+test('validateSessionToken calls /api/auth/validate with Bearer header', async function() {
+  let capturedOpts = null
+
+  const { auth } = setup({
+    getStorageSync: function(key) {
+      if (key === 'sessionToken') return 'my-jwt'
+      return ''
+    },
+    setStorageSync: function() {},
+    removeStorageSync: function() {},
+    showModal: function() {},
+    reLaunch: function() {},
+    request: function(opts) {
+      capturedOpts = opts
+      opts.success({ statusCode: 200, data: { code: 200, success: true, message: 'success', data: null } })
+    }
+  })
+
+  await auth.validateSessionToken()
+
+  assert.ok(capturedOpts.url.includes('/api/auth/validate'), 'should call lightweight validate endpoint')
+  assert.ok(!capturedOpts.url.includes('/api/user/profile'), 'should NOT call heavyweight profile endpoint')
+  assert.equal(capturedOpts.header.Authorization, 'Bearer my-jwt')
+  assert.equal(capturedOpts.method, 'GET')
+})
+
+// ---- validateSessionToken cleanup boundary ----
+
+test('validateSessionToken does NOT clear session on 401 — cleanup is caller responsibility', async function() {
+  let removeKeys = []
+
+  const { auth } = setup({
+    getStorageSync: function(key) {
+      if (key === 'sessionToken') return 'expired-jwt'
+      return ''
+    },
+    setStorageSync: function() {},
+    removeStorageSync: function(key) { removeKeys.push(key) },
+    showModal: function() {},
+    reLaunch: function() {},
+    request: function(opts) {
+      opts.success({ statusCode: 401, data: { code: 401, message: 'Unauthorized' } })
+    }
+  })
+
+  const result = await auth.validateSessionToken()
+
+  assert.equal(result, false)
+  assert.equal(removeKeys.length, 0, 'validateSessionToken should not call clearSession — that is the caller\'s job')
+})
+
+// ---- request correlation ----
+
+test('validateSessionToken includes X-Request-ID header', async function() {
+  let capturedOpts = null
+
+  const { auth } = setup({
+    getStorageSync: function(key) {
+      if (key === 'sessionToken') return 'my-jwt'
+      return ''
+    },
+    setStorageSync: function() {},
+    removeStorageSync: function() {},
+    showModal: function() {},
+    reLaunch: function() {},
+    request: function(opts) {
+      capturedOpts = opts
+      opts.success({ statusCode: 200, data: { code: 200, success: true, message: 'success', data: null } })
+    }
+  })
+
+  await auth.validateSessionToken()
+
+  assert.ok(capturedOpts.header['X-Request-ID'], 'X-Request-ID should be present')
+  assert.match(capturedOpts.header['X-Request-ID'], /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+})
+
+test('logout includes X-Request-ID header', async function() {
+  let capturedOpts = null
+
+  const { auth } = setup({
+    getStorageSync: function(key) {
+      if (key === 'sessionToken') return 'my-jwt'
+      return ''
+    },
+    setStorageSync: function() {},
+    removeStorageSync: function() {},
+    showModal: function() {},
+    reLaunch: function() {},
+    request: function(opts) {
+      capturedOpts = opts
+      if (opts.complete) opts.complete()
+    }
+  })
+
+  await auth.logout()
+
+  assert.ok(capturedOpts.header['X-Request-ID'], 'X-Request-ID should be present')
+  assert.match(capturedOpts.header['X-Request-ID'], /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+})
+
+// ---- logout ----
+
+test('logout resolves immediately when no token stored', async function() {
+  const { auth } = setup()
+  await auth.logout()
+  // no error = pass
+})

--- a/tests/request.test.js
+++ b/tests/request.test.js
@@ -1,0 +1,200 @@
+const path = require('node:path')
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { clearModule, stubModule } = require('./helpers/module.js')
+
+const ROOT = path.resolve(__dirname, '..')
+const REQUEST_MODULE = path.join(ROOT, 'services/request.js')
+const AUTH_MODULE = path.join(ROOT, 'services/auth.js')
+const DATA_SOURCE_MODULE = path.join(ROOT, 'services/data-source.js')
+const MOCK_MODULE = path.join(ROOT, 'mock/index.js')
+const CONFIG_MODULE = path.join(ROOT, 'config/index.js')
+
+function setup(wxRequestImpl) {
+  // Stub wx global
+  const storage = {}
+  global.wx = {
+    getDeviceInfo: function() { return { deviceId: 'test-device-id' } },
+    getStorageSync: function(key) { return storage[key] || '' },
+    setStorageSync: function(key, val) { storage[key] = val },
+    removeStorageSync: function(key) { delete storage[key] },
+    showNavigationBarLoading: function() {},
+    hideNavigationBarLoading: function() {},
+    showLoading: function() {},
+    hideLoading: function() {},
+    showModal: function() {},
+    reLaunch: function() {},
+    request: wxRequestImpl || function() {}
+  }
+  global.getApp = function() {
+    return { globalData: { locale: 'zh-CN' } }
+  }
+
+  // Stub dependencies
+  stubModule(CONFIG_MODULE, {
+    resourceDomain: 'https://test.example.com/',
+    requestTimeout: 5000,
+    currentEnv: 'prod'
+  })
+  stubModule(AUTH_MODULE, {
+    getSessionToken: function() { return storage.sessionToken || '' },
+    setSessionToken: function(t) { storage.sessionToken = t },
+    clearSession: function() { delete storage.sessionToken },
+    reLaunchToLogin: function() {},
+    ensureSessionToken: function() {
+      const token = storage.sessionToken
+      if (token) return Promise.resolve(token)
+      return Promise.reject(new Error('no token'))
+    }
+  })
+  stubModule(DATA_SOURCE_MODULE, {
+    isMockMode: function() { return false }
+  })
+  stubModule(MOCK_MODULE, {})
+
+  clearModule(REQUEST_MODULE)
+  return require(REQUEST_MODULE)
+}
+
+// ---- generateRequestId ----
+
+test('generateRequestId returns a non-empty UUID-shaped string', function() {
+  const { generateRequestId } = setup()
+  const id = generateRequestId()
+  assert.ok(id.length > 0, 'should be non-empty')
+  assert.match(id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+})
+
+test('generateRequestId returns unique values', function() {
+  const { generateRequestId } = setup()
+  const ids = new Set()
+  for (let i = 0; i < 50; i++) {
+    ids.add(generateRequestId())
+  }
+  assert.equal(ids.size, 50, 'all 50 IDs should be unique')
+})
+
+// ---- X-Request-ID header ----
+
+test('request includes X-Request-ID header in outbound calls', async function() {
+  let capturedHeader = null
+
+  const { request } = setup(function(opts) {
+    capturedHeader = opts.header
+    opts.success({ statusCode: 200, data: { code: 200, data: null } })
+  })
+
+  await request({ url: '/api/test' })
+
+  assert.ok(capturedHeader['X-Request-ID'], 'X-Request-ID should be present')
+  assert.match(capturedHeader['X-Request-ID'], /^[0-9a-f-]+$/)
+})
+
+test('request preserves caller-supplied requestId', async function() {
+  let capturedHeader = null
+
+  const { request } = setup(function(opts) {
+    capturedHeader = opts.header
+    opts.success({ statusCode: 200, data: { code: 200, data: null } })
+  })
+
+  await request({ url: '/api/test', requestId: 'custom-rid-001' })
+
+  assert.equal(capturedHeader['X-Request-ID'], 'custom-rid-001')
+})
+
+// ---- Auth header injection ----
+
+test('request injects Authorization header when authRequired', async function() {
+  let capturedHeader = null
+
+  const { request } = setup(function(opts) {
+    capturedHeader = opts.header
+    opts.success({ statusCode: 200, data: { code: 200, data: null } })
+  })
+
+  // Set a token in storage so ensureSessionToken resolves
+  global.wx.setStorageSync('sessionToken', 'my-jwt-token')
+  clearModule(AUTH_MODULE)
+  stubModule(AUTH_MODULE, {
+    getSessionToken: function() { return 'my-jwt-token' },
+    clearSession: function() {},
+    reLaunchToLogin: function() {},
+    ensureSessionToken: function() { return Promise.resolve('my-jwt-token') }
+  })
+  clearModule(REQUEST_MODULE)
+  const mod = require(REQUEST_MODULE)
+
+  await mod.request({ url: '/api/protected', authRequired: true })
+
+  assert.equal(capturedHeader.Authorization, 'Bearer my-jwt-token')
+})
+
+test('request omits Authorization header when not authRequired', async function() {
+  let capturedHeader = null
+
+  const { request } = setup(function(opts) {
+    capturedHeader = opts.header
+    opts.success({ statusCode: 200, data: { code: 200, data: null } })
+  })
+
+  await request({ url: '/api/public', authRequired: false })
+
+  assert.equal(capturedHeader.Authorization, undefined)
+})
+
+// ---- 401 handling ----
+
+test('request rejects and clears session on 401 response', async function() {
+  let sessionCleared = false
+
+  const { request } = setup(function(opts) {
+    opts.success({ statusCode: 401, data: {} })
+  })
+
+  // Override auth stub to track clearSession
+  stubModule(AUTH_MODULE, {
+    getSessionToken: function() { return '' },
+    clearSession: function() { sessionCleared = true },
+    reLaunchToLogin: function() {},
+    ensureSessionToken: function() { return Promise.resolve(null) }
+  })
+  clearModule(REQUEST_MODULE)
+  const mod = require(REQUEST_MODULE)
+
+  await assert.rejects(
+    mod.request({ url: '/api/test' }),
+    { message: '登录凭证已过期，请重新登录' }
+  )
+  assert.ok(sessionCleared, 'clearSession should have been called')
+})
+
+// ---- Payload normalization ----
+
+test('request normalizes successful response through normalizePayload', async function() {
+  const { request } = setup(function(opts) {
+    opts.success({ statusCode: 200, data: { code: 200, msg: 'ok', data: { id: 1 } } })
+  })
+
+  const result = await request({ url: '/api/data' })
+
+  assert.equal(result.success, true)
+  assert.deepEqual(result.data, { id: 1 })
+})
+
+// ---- Default headers ----
+
+test('request includes Accept-Language and X-Device-ID headers', async function() {
+  let capturedHeader = null
+
+  const { request } = setup(function(opts) {
+    capturedHeader = opts.header
+    opts.success({ statusCode: 200, data: { code: 200, data: null } })
+  })
+
+  await request({ url: '/api/test' })
+
+  assert.equal(capturedHeader['Accept-Language'], 'zh-CN')
+  assert.equal(capturedHeader['X-Device-ID'], 'test-device-id')
+})


### PR DESCRIPTION
## Summary
- Add `X-Request-ID` to all outbound requests (business requests via `request.js`, auth validate/logout via `auth.js`) using shared `request-id.js` module
- Add debug-safe structured logging: request id, method, path, status, latency (no token/body logging)
- **Switch `validateSessionToken()` from `/api/user/profile` to `/api/auth/validate`** — lightweight JWT + Redis session check, no full profile fetch
- Add `package.json` with Node built-in test runner (`npm test`)
- Add `tests/request.test.js` (9 tests), `tests/auth.test.js` (15 tests)
- Add `wechat-ci.yml` GitHub Actions workflow
- Update README with test/run instructions

## Dependencies
- **Requires backend `GET /api/auth/validate`** — merge [GdeiAssistant#105](https://github.com/GdeiAssistant/GdeiAssistant/pull/105) first

## Test plan
- [ ] `npm test` — 100 tests, 0 failures
- [ ] Verify login page session restore works with new `/api/auth/validate` endpoint
- [ ] Verify token expiry still triggers cleanup + re-login UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)