### PR TITLE
[codex] align WeChat primary color with WeUI

### DIFF
--- a/styles/theme.wxss
+++ b/styles/theme.wxss
@@ -11,8 +11,8 @@ page {
   --color-text-tertiary: #999999;
   --color-border: #e5e7eb;
   --color-divider: #ececec;
-  --color-primary: #047857;
-  --color-primary-hover: #065F46;
+  --color-primary: #07C160;
+  --color-primary-hover: #06AD56;
   --color-danger: #e94747;
   --color-link: #576b95;
 }


### PR DESCRIPTION
## What changed
- replace the custom primary green tokens with the standard WeUI green and hover color

## Why
- align the WeChat client with the native platform visual language instead of carrying a separate green palette

## Impact
- primary actions feel more native inside WeChat while keeping the rest of the theme unchanged

## Validation
- npm test