### PR TITLE
[codex] upgrade Actions to Node 24 and CodeQL v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/hide-codex-limit-comments.yml
+++ b/.github/workflows/hide-codex-limit-comments.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Minimize comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const mutation = `

--- a/.github/workflows/wechat-ci.yml
+++ b/.github/workflows/wechat-ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## What changed
- upgrade `actions/checkout` to v5 and `actions/setup-node` to v5 in WeChat CI
- upgrade `github/codeql-action` from v3 to v4
- upgrade `actions/github-script` from v7 to v8 in the Codex comment minimizer workflow

## Why
- remove GitHub Actions warnings about Node.js 20 deprecation
- remove the CodeQL Action v3 deprecation warning before the workflow starts breaking in the future

## Validation
- ruby YAML parse for all workflow files in this repo