### PR TITLE
[codex] expand lint coverage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,16 @@
 module.exports = [
   {
-    files: ['services/**/*.js', 'utils/**/*.js', 'tests/**/*.js'],
+    files: [
+      'app.js',
+      'config/**/*.js',
+      'constants/**/*.js',
+      'mock/**/*.js',
+      'pages/**/*.js',
+      'services/**/*.js',
+      'utils/**/*.js',
+      'tests/**/*.js',
+      'scripts/**/*.js'
+    ],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: 'commonjs',

--- a/mock/profile-handlers.js
+++ b/mock/profile-handlers.js
@@ -1,4 +1,5 @@
 var LOCATION_REGIONS = require('../constants/location-regions.js')
+var i18n = require('../utils/i18n.js')
 var {
   getDefaultProfileOptionsPayload,
   getFacultyDictionaryOptions,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "广东二师助手微信小程序",
   "scripts": {
-    "lint": "eslint services utils tests",
+    "lint": "eslint app.js config constants mock pages services utils tests scripts",
     "format": "prettier --write \"services/**/*.js\" \"utils/**/*.js\" \"tests/**/*.js\"",
     "format:check": "prettier --check \"services/**/*.js\" \"utils/**/*.js\" \"tests/**/*.js\"",
     "smoke": "node scripts/ci-smoke.js",

--- a/scripts/migrate-colors.js
+++ b/scripts/migrate-colors.js
@@ -29,7 +29,6 @@ const COLOR_MAP = {
   '#e3e3e3': 'var(--color-divider)',
   '#dfdfdf': 'var(--color-border)',
   '#047857': 'var(--color-primary)',
-  '#047857': 'var(--color-primary)',
   '#09bb07': 'var(--color-primary)',
   '#e94747': 'var(--color-danger)',
   '#576b95': 'var(--color-link)',


### PR DESCRIPTION
## What
- Expand ESLint coverage beyond services/utils/tests to app/config/constants/mock/pages/scripts.
- Fix the newly surfaced missing i18n import in mock profile handlers.
- Remove a duplicate color mapping key in the color migration script.

## Why
The previous lint scope missed large parts of the mini-program codebase and allowed simple issues to slip through.

## Impact
Future lint runs now cover more application code. No runtime behavior change is intended except the mock handler import fix.

## Checks
- `npm run lint && npm test`
- `git diff --check`