### PR TITLE
[codex] mock paged secret profile endpoint

### DIFF
--- a/mock/community.js
+++ b/mock/community.js
@@ -871,6 +871,18 @@ function handleSecret(path, method, data, token, utils) {
     return utils.resolveWithDelay(utils.buildSuccess(list))
   }
 
+  if (/^\/api\/secret\/profile\/start\/\d+\/size\/\d+$/.test(path) && method === 'GET') {
+    const matched = /^\/api\/secret\/profile\/start\/(\d+)\/size\/(\d+)$/.exec(path)
+    const start = Number(matched[1])
+    const size = Math.min(Number(matched[2]), 50)
+    const list = communityState.secrets.filter(function(item) {
+      return item.owner === username
+    }).slice(start, start + size).map(function(item) {
+      return buildSecretPayload(item, username, communityState.secretComments[item.id] || [])
+    })
+    return utils.resolveWithDelay(utils.buildSuccess(list))
+  }
+
   if (path === '/api/secret/profile' && method === 'GET') {
     const list = communityState.secrets.filter(function(item) {
       return item.owner === username

--- a/tests/mock-smoke.test.js
+++ b/tests/mock-smoke.test.js
@@ -266,6 +266,9 @@ test('mock smoke covers community feature flows', async function () {
     token
   })
   assert.ok(Array.isArray(secretComments.data))
+  const secretProfile = await request(router, '/api/secret/profile/start/0/size/10', { token })
+  assert.ok(Array.isArray(secretProfile.data))
+  assert.ok(secretProfile.data.length <= 10)
 
   const dating = await request(router, '/api/dating/profile/area/0/start/0', { token })
   assert.ok(Array.isArray(dating.data) && dating.data.length > 0)


### PR DESCRIPTION
## Summary
- add mock handling for `/api/secret/profile/start/{start}/size/{size}`
- keep the same 50-item cap as the backend route
- extend the community mock smoke test to cover the paged profile path

## Why
The app code already calls the paged Secret Center profile endpoint. The mock server should mirror that contract so local and CI smoke coverage exercise the same route shape.

## Validation
- `npm test -- --test-name-pattern='mock smoke covers community feature flows'`
- `npm run lint`
- `git diff --check`