### PR TITLE
[codex] align delivery mock pickup code

### DIFF
--- a/tests/mock-route-contract.test.js
+++ b/tests/mock-route-contract.test.js
@@ -297,7 +297,7 @@ function buildRouteContracts(endpoints) {
     routeContract('delivery.publish', 'POST', endpoints.community.delivery.publish, {
       data: form({
         name: '快递代拿',
-        number: 'C001',
+        number: '00000000000',
         phone: '13612340001',
         price: 4,
         company: '菜鸟驿站',


### PR DESCRIPTION
## Summary
- Update the WeChat mock route delivery publish contract to use the backend-compatible `00000000000` pickup-code placeholder instead of the short `C001` sample.

## Validation
- `npm test -- --test-name-pattern='mock route'`
- `npm run lint`
- `git diff --check`