### PR TITLE
[codex] validate marketplace price boundary

### DIFF
--- a/services/community/module-handlers/marketplace.js
+++ b/services/community/module-handlers/marketplace.js
@@ -8,6 +8,7 @@ var SECONDHAND_NAME_MAX_LENGTH = 25
 var SECONDHAND_DESCRIPTION_MAX_LENGTH = 100
 var SECONDHAND_LOCATION_MAX_LENGTH = 30
 var SECONDHAND_QQ_MAX_LENGTH = 20
+var SECONDHAND_PRICE_MAX = 9999.99
 var CONTACT_PHONE_MAX_LENGTH = 11
 
 function trimValue(value) {
@@ -30,6 +31,11 @@ function findLabel(options, value, fallback) {
 function formatPrice(value) {
   const price = Number(value || 0)
   return price ? price.toFixed(2) : '0.00'
+}
+
+function isValidSecondhandPrice(value) {
+  var price = Number(value || 0)
+  return Number.isFinite(price) && price > 0 && price <= SECONDHAND_PRICE_MAX
 }
 
 module.exports = {
@@ -236,7 +242,7 @@ module.exports = {
           max: SECONDHAND_DESCRIPTION_MAX_LENGTH
         })
       )
-    if (!(Number(form.price || 0) > 0)) return i18n.t('community.publish.v.priceInvalid')
+    if (!isValidSecondhandPrice(form.price)) return i18n.t('community.publish.v.priceInvalid')
     if (!location) return i18n.t('community.publish.v.locationRequired')
     if (
       getMaxLengthMessage(

--- a/tests/community-registry.test.js
+++ b/tests/community-registry.test.js
@@ -558,6 +558,26 @@ test('marketplace validateForm passes with valid data', function () {
   assert.equal(result, '', 'should return empty string for valid form')
 })
 
+test('marketplace validateForm accepts backend maximum price', function () {
+  var handler = getModuleHandler('marketplace')
+  var result = handler.validateForm({
+    form: { name: 'Test', description: 'Desc', price: 9999.99, location: 'A', qq: '123' },
+    images: [{ path: '/img/test.png' }],
+    isEditMode: false
+  })
+  assert.equal(result, '', 'should return empty string for backend maximum price')
+})
+
+test('marketplace validateForm rejects price above backend maximum', function () {
+  var handler = getModuleHandler('marketplace')
+  var result = handler.validateForm({
+    form: { name: 'Test', description: 'Desc', price: 10000, location: 'A', qq: '123' },
+    images: [{ path: '/img/test.png' }],
+    isEditMode: false
+  })
+  assert.equal(result, 'community.publish.v.priceInvalid')
+})
+
 test('lostandfound validateForm rejects when no contact info', function () {
   var handler = getModuleHandler('lostandfound')
   var result = handler.validateForm({


### PR DESCRIPTION
## Summary
- Add WeChat marketplace publish price validation for the backend maximum of 9999.99.
- Cover the inclusive maximum and above-maximum rejection in community registry tests.

## Validation
- `npm test -- --test-name-pattern='marketplace validateForm'` (ran the full node test suite; 128 passing)
- `npm run lint`
- `npm run format:check`
- `git diff --check`