### PR TITLE
[codex] let photograph derive image count

### DIFF
--- a/services/community/module-handlers/photograph.js
+++ b/services/community/module-handlers/photograph.js
@@ -190,7 +190,6 @@ module.exports = {
       return {
         title: String(form.title || '').trim(),
         content: String(form.content || '').trim(),
-        count: imageKeys.length,
         type: photographTypeOptions[photographTypeIndex].publishValue,
         imageKeys: imageKeys
       }

--- a/tests/community-registry.test.js
+++ b/tests/community-registry.test.js
@@ -578,6 +578,29 @@ test('marketplace validateForm rejects price above backend maximum', function ()
   assert.equal(result, 'community.publish.v.priceInvalid')
 })
 
+test('photograph buildPublishPayload lets backend derive image count', async function () {
+  var handler = getModuleHandler('photograph')
+  var result = await handler.buildPublishPayload(
+    {
+      form: { title: 'Campus', content: 'Photo' },
+      images: [{ path: '/img/photo.png' }],
+      photographTypeOptions: [{ publishValue: 1 }],
+      photographTypeIndex: 0
+    },
+    function () {
+      return Promise.resolve(['upload/photo.jpg'])
+    }
+  )
+
+  assert.deepEqual(result, {
+    title: 'Campus',
+    content: 'Photo',
+    type: 1,
+    imageKeys: ['upload/photo.jpg']
+  })
+  assert.equal(Object.prototype.hasOwnProperty.call(result, 'count'), false)
+})
+
 test('lostandfound validateForm rejects when no contact info', function () {
   var handler = getModuleHandler('lostandfound')
   var result = handler.validateForm({


### PR DESCRIPTION
## Summary
- Remove the redundant `count` field from photograph publish payloads.
- Keep topic publish payloads unchanged because that contract still sends count explicitly.
- Add a WeChat unit test that asserts photograph payloads let the backend derive image count from uploaded image keys.

## Validation
- `npm test -- --test-name-pattern='photograph buildPublishPayload|mock router handles all WeChat endpoint route contracts'`
  - 129 tests passed
- `npm run lint`
- `npm run format:check`
- `git diff --check`