### PR TITLE
[codex] let topic derive image count

### DIFF
--- a/services/community/module-handlers/topic.js
+++ b/services/community/module-handlers/topic.js
@@ -166,7 +166,6 @@ module.exports = {
       return {
         topic: String(form.topic || '').trim(),
         content: String(form.content || '').trim(),
-        count: imageKeys.length,
         imageKeys: imageKeys
       }
     })

--- a/tests/community-registry.test.js
+++ b/tests/community-registry.test.js
@@ -578,6 +578,26 @@ test('marketplace validateForm rejects price above backend maximum', function ()
   assert.equal(result, 'community.publish.v.priceInvalid')
 })
 
+test('topic buildPublishPayload lets backend derive image count', async function () {
+  var handler = getModuleHandler('topic')
+  var result = await handler.buildPublishPayload(
+    {
+      form: { topic: 'Campus', content: 'Topic content' },
+      images: [{ path: '/img/topic.png' }]
+    },
+    function () {
+      return Promise.resolve(['upload/topic.jpg'])
+    }
+  )
+
+  assert.deepEqual(result, {
+    topic: 'Campus',
+    content: 'Topic content',
+    imageKeys: ['upload/topic.jpg']
+  })
+  assert.equal(Object.prototype.hasOwnProperty.call(result, 'count'), false)
+})
+
 test('photograph buildPublishPayload lets backend derive image count', async function () {
   var handler = getModuleHandler('photograph')
   var result = await handler.buildPublishPayload(


### PR DESCRIPTION
## Summary
- Remove the redundant `count` field from topic publish payloads.
- Keep sending `imageKeys` so the backend derives the topic image count from uploaded images.
- Add a WeChat registry test for the topic publish payload shape.

## Validation
- `npm test -- --test-name-pattern='topic buildPublishPayload|photograph buildPublishPayload'`
  - 130 tests passed
- `npm run lint`
- `npm run format:check`
- `git diff --check`