### PR TITLE
Lower mock login control weight

### DIFF
--- a/pages/login/login.wxml
+++ b/pages/login/login.wxml
@@ -39,20 +39,16 @@
 
     </form>
 
-    <view class="weui-cells__title">{{t.debugSettings}}</view>
-    <view class="weui-cells weui-cells_after-title">
-      <view class="weui-cell weui-cell_switch">
-        <view class="weui-cell__bd">{{t.useMockData}}</view>
-        <view class="weui-cell__ft">
-          <switch checked="{{useMockData}}" bindchange="handleDataSourceChange" />
-        </view>
+    <view class="login_aux">
+      <view class="mock_toolbar">
+        <text class="mock_label">{{t.useMockData}}</text>
+        <switch class="mock_switch" checked="{{useMockData}}" bindchange="handleDataSourceChange" />
       </view>
+      <text wx:if="{{useMockData}}" class="mock_hint">{{mockCredentialsHint}}</text>
+      <navigator url="/pages/settings/settings" class="settings_link" hover-class="none">
+        {{t.moreSettings}}
+      </navigator>
     </view>
-
-    <text wx:if="{{useMockData}}" class="mock_hint">{{mockCredentialsHint}}</text>
-    <navigator url="/pages/settings/settings" class="settings_link" hover-class="none">
-      {{t.moreSettings}}
-    </navigator>
   </view>
 
   <view class="version_info">

--- a/pages/login/login.wxss
+++ b/pages/login/login.wxss
@@ -35,20 +35,43 @@ form {
   font-size: 26rpx;
 }
 
+.login_aux {
+  margin-top: 36rpx;
+  padding-top: 24rpx;
+  border-top: 1rpx solid var(--color-border);
+}
+
+.mock_toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 8rpx;
+}
+
+.mock_label {
+  color: var(--color-text-tertiary);
+  font-size: 24rpx;
+}
+
+.mock_switch {
+  transform: scale(0.82);
+  transform-origin: right center;
+}
+
 .mock_hint {
   display: block;
-  margin: 20rpx 40rpx 0;
-  color: var(--color-text-secondary);
-  text-align: center;
-  font-size: 26rpx;
+  margin: 12rpx 8rpx 0;
+  color: var(--color-text-tertiary);
+  font-size: 24rpx;
+  line-height: 1.5;
 }
 
 .settings_link {
   display: block;
-  margin-top: 20rpx;
-  color: var(--color-link);
-  text-align: center;
-  font-size: 28rpx;
+  margin-top: 14rpx;
+  padding: 0 8rpx;
+  color: var(--color-text-tertiary);
+  font-size: 24rpx;
 }
 
 .consent_section {


### PR DESCRIPTION
Summary: move the WeChat login mock switch into a compact auxiliary toolbar below the form. Verification: npm run lint; node --test tests/login-consent.test.js tests/mock-ui-smoke.test.js.