### PR TITLE
Harden release demo controls and polish login UI

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -20,11 +20,21 @@ function normalizeDomain(domain) {
   return domain.endsWith('/') ? domain : `${domain}/`
 }
 
-function resolveCurrentEnv() {
+function resolveMiniProgramEnvVersion() {
   try {
     if (typeof wx !== 'undefined' && wx.getAccountInfoSync) {
       const accountInfo = wx.getAccountInfoSync()
-      const envVersion = accountInfo && accountInfo.miniProgram ? accountInfo.miniProgram.envVersion : ''
+      return accountInfo && accountInfo.miniProgram ? accountInfo.miniProgram.envVersion || '' : ''
+    }
+  } catch (error) {
+    // Ignore runtime detection failure and fallback below.
+  }
+  return ''
+}
+
+function resolveCurrentEnv(envVersion) {
+  try {
+    if (envVersion) {
       // WeChat runtime mapping:
       // develop -> local development
       // trial -> staging
@@ -54,6 +64,18 @@ function resolveCurrentEnv() {
   }
 
   return 'prod'
+}
+
+function resolveAllowRuntimeDebugOptions(currentEnv, envVersion) {
+  if (typeof wx !== 'undefined') {
+    return envVersion !== 'release'
+  }
+
+  if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV) {
+    return process.env.NODE_ENV !== 'production'
+  }
+
+  return currentEnv !== 'prod'
 }
 
 function isDevtoolsRuntime() {
@@ -91,11 +113,13 @@ function resolveResourceDomain(currentEnv) {
   return normalizeDomain(ENV_CONFIG.prod.resourceDomain)
 }
 
-const currentEnv = resolveCurrentEnv()
+const miniProgramEnvVersion = resolveMiniProgramEnvVersion()
+const currentEnv = resolveCurrentEnv(miniProgramEnvVersion)
 const envConfig = ENV_CONFIG[currentEnv] || ENV_CONFIG.prod
 
 module.exports = {
   currentEnv,
+  allowRuntimeDebugOptions: resolveAllowRuntimeDebugOptions(currentEnv, miniProgramEnvVersion),
   ...envConfig,
   resourceDomain: resolveResourceDomain(currentEnv)
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -62,6 +62,9 @@
     "useMockData": "Use demo data",
     "moreSettings": "More settings",
     "campusCredentialConsentText": "I have read and separately agree that the platform may process my campus credential within the necessary scope for campus identity verification, quick authentication, campus data queries, and required session synchronization with school systems. I understand that I can revoke consent, delete saved credentials, or disable quick authentication in Settings, and some campus queries may require re-login or re-authorization afterward.",
+    "campusCredentialConsentSummary": "I agree to the separate campus credential authorization",
+    "campusCredentialConsentDetailAction": "View details",
+    "campusCredentialConsentDetailTitle": "Campus credential authorization",
     "campusCredentialConsentRequired": "Please confirm campus credential consent before logging in"
   },
   "auth": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -62,6 +62,9 @@
     "useMockData": "デモデータを使用",
     "moreSettings": "その他の設定",
     "campusCredentialConsentText": "私は、学内認証、クイック認証、学内データ照会、および学校システムとの必要なセッション同期のために、必要な範囲で学内アカウント資格情報が処理されることに個別に同意します。設定から同意を撤回したり、保存済み資格情報を削除したり、クイック認証を無効化できることを理解しています。",
+    "campusCredentialConsentSummary": "学内資格情報の個別許可に同意します",
+    "campusCredentialConsentDetailAction": "詳細を見る",
+    "campusCredentialConsentDetailTitle": "学内資格情報の許可説明",
     "campusCredentialConsentRequired": "ログインする前に学内資格情報への同意を確認してください"
   },
   "auth": {

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -62,6 +62,9 @@
     "useMockData": "데모 데이터 사용",
     "moreSettings": "추가 설정",
     "campusCredentialConsentText": "저는 캠퍼스 인증, 빠른 인증, 캠퍼스 데이터 조회 및 학교 시스템과의 필요한 세션 동기화를 위해 필요한 범위 내에서 학교 계정 자격정보가 처리되는 것에 별도로 동의합니다. 설정에서 동의를 철회하거나 저장된 자격정보를 삭제하거나 빠른 인증을 끌 수 있음을 이해합니다.",
+    "campusCredentialConsentSummary": "캠퍼스 자격정보 별도 승인에 동의합니다",
+    "campusCredentialConsentDetailAction": "자세히 보기",
+    "campusCredentialConsentDetailTitle": "캠퍼스 자격정보 승인 안내",
     "campusCredentialConsentRequired": "로그인하기 전에 캠퍼스 자격정보 동의를 확인해 주세요"
   },
   "auth": {

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -62,6 +62,9 @@
     "useMockData": "使用演示数据",
     "moreSettings": "更多功能设置",
     "campusCredentialConsentText": "我已阅读并单独同意平台在必要范围内处理我的校园账号凭证，用于校园身份认证、快速认证、校园数据查询及与学校系统的必要会话同步。我知悉可在设置中撤回授权、删除已保存凭证或关闭快速认证；关闭或删除后，部分校园查询功能可能需要重新登录或重新授权。",
+    "campusCredentialConsentSummary": "我已阅读并同意校园凭证单独授权",
+    "campusCredentialConsentDetailAction": "查看详情",
+    "campusCredentialConsentDetailTitle": "校园凭证授权说明",
     "campusCredentialConsentRequired": "请先勾选校园凭证单独授权后再登录"
   },
   "auth": {

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -62,6 +62,9 @@
     "useMockData": "使用示範數據",
     "moreSettings": "更多功能設定",
     "campusCredentialConsentText": "我已閱讀並單獨同意平台在必要範圍內處理我的校園賬號憑證，用於校園身份認證、快速認證、校園數據查詢及與學校系統的必要會話同步。我知悉可在設定中撤回授權、刪除已保存憑證或關閉快速認證；關閉或刪除後，部分校園查詢功能可能需要重新登入或重新授權。",
+    "campusCredentialConsentSummary": "我已閱讀並同意校園憑證單獨授權",
+    "campusCredentialConsentDetailAction": "查看詳情",
+    "campusCredentialConsentDetailTitle": "校園憑證授權說明",
     "campusCredentialConsentRequired": "請先勾選校園憑證單獨授權後再登入"
   },
   "auth": {

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -62,6 +62,9 @@
     "useMockData": "使用示範資料",
     "moreSettings": "更多功能設定",
     "campusCredentialConsentText": "我已閱讀並單獨同意平台在必要範圍內處理我的校園帳號憑證，用於校園身分認證、快速認證、校園資料查詢及與學校系統的必要會話同步。我知悉可在設定中撤回授權、刪除已保存憑證或關閉快速認證；關閉或刪除後，部分校園查詢功能可能需要重新登入或重新授權。",
+    "campusCredentialConsentSummary": "我已閱讀並同意校園憑證單獨授權",
+    "campusCredentialConsentDetailAction": "查看詳情",
+    "campusCredentialConsentDetailTitle": "校園憑證授權說明",
     "campusCredentialConsentRequired": "請先勾選校園憑證單獨授權後再登入"
   },
   "auth": {

--- a/pages/appearance/appearance.js
+++ b/pages/appearance/appearance.js
@@ -12,7 +12,7 @@ Page({
     currentLocale: '',
     locales: [
       { code: 'zh-CN', label: '简体中文' },
-      { code: 'zh-HK', label: '繁體中文（香港）' },
+      { code: 'zh-HK', label: '繁體中文（港澳）' },
       { code: 'zh-TW', label: '繁體中文（台灣）' },
       { code: 'en', label: 'English' },
       { code: 'ja', label: '日本語' },

--- a/pages/login/login.js
+++ b/pages/login/login.js
@@ -18,6 +18,7 @@ Page({
     ready: false,
     versionCode: '',
     useMockData: false,
+    canUseDemoMode: false,
     dataSourceLabel: '',
     mockCredentialsHint: '',
     campusCredentialConsent: false
@@ -34,6 +35,9 @@ Page({
         passwordPlaceholder: i18n.t('login.passwordPlaceholder'),
         button: i18n.t('login.button'),
         campusCredentialConsentText: i18n.t('login.campusCredentialConsentText'),
+        campusCredentialConsentSummary: i18n.t('login.campusCredentialConsentSummary'),
+        campusCredentialConsentDetailAction: i18n.t('login.campusCredentialConsentDetailAction'),
+        campusCredentialConsentDetailTitle: i18n.t('login.campusCredentialConsentDetailTitle'),
         campusCredentialConsentRequired: i18n.t('login.campusCredentialConsentRequired'),
         debugSettings: i18n.t('login.debugSettings'),
         useMockData: i18n.t('login.useMockData'),
@@ -42,6 +46,14 @@ Page({
       mockCredentialsHint: getMockCredentialsHint()
     })
     wx.setNavigationBarTitle({ title: this.data.t.navTitle })
+  },
+
+  showCampusCredentialConsentDetail: function() {
+    wx.showModal({
+      title: this.data.t.campusCredentialConsentDetailTitle,
+      content: this.data.t.campusCredentialConsentText,
+      showCancel: false
+    })
   },
 
   formSubmit: function(e) {
@@ -104,6 +116,7 @@ Page({
 
   refreshRuntimeState: function() {
     this.setData({
+      canUseDemoMode: dataSource.canUseDemoMode(),
       useMockData: dataSource.isMockMode()
     })
   },
@@ -116,6 +129,13 @@ Page({
   },
 
   handleDataSourceChange: function(event) {
+    if (!dataSource.canUseDemoMode()) {
+      dataSource.setDataSourceMode(dataSource.DATA_SOURCE_MODES.remote)
+      this.refreshRuntimeState()
+      this.refreshI18n()
+      return
+    }
+
     const useMockData = !!event.detail.value
     dataSource.setDataSourceMode(useMockData ? dataSource.DATA_SOURCE_MODES.mock : dataSource.DATA_SOURCE_MODES.remote)
     auth.clearSession()

--- a/pages/login/login.wxml
+++ b/pages/login/login.wxml
@@ -28,7 +28,10 @@
         <checkbox-group bindchange="handleConsentChange">
           <label class="consent_label">
             <checkbox value="agree" checked="{{campusCredentialConsent}}" />
-            <text class="consent_text">{{t.campusCredentialConsentText}}</text>
+            <view class="consent_text">
+              <text>{{t.campusCredentialConsentSummary}}</text>
+              <text class="consent_detail_link" catchtap="showCampusCredentialConsentDetail">{{t.campusCredentialConsentDetailAction}}</text>
+            </view>
           </label>
         </checkbox-group>
       </view>
@@ -40,11 +43,11 @@
     </form>
 
     <view class="login_aux">
-      <view class="mock_toolbar">
+      <view wx:if="{{canUseDemoMode}}" class="mock_toolbar">
         <text class="mock_label">{{t.useMockData}}</text>
         <switch class="mock_switch" checked="{{useMockData}}" bindchange="handleDataSourceChange" />
       </view>
-      <text wx:if="{{useMockData}}" class="mock_hint">{{mockCredentialsHint}}</text>
+      <text wx:if="{{canUseDemoMode && useMockData}}" class="mock_hint">{{mockCredentialsHint}}</text>
       <navigator url="/pages/settings/settings" class="settings_link" hover-class="none">
         {{t.moreSettings}}
       </navigator>

--- a/pages/login/login.wxss
+++ b/pages/login/login.wxss
@@ -89,6 +89,15 @@ form {
 
 .consent_text {
   flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  min-width: 0;
+}
+
+.consent_detail_link {
+  margin-left: 12rpx;
+  color: var(--color-link);
 }
 
 .version_info {

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -49,6 +49,7 @@ Page({
     t: {},
     themeClass: '',
     useMockData: false,
+    canUseDemoMode: false,
     dataSourceLabel: '',
     mockCredentialsHint: '',
     featureSections: [],
@@ -61,6 +62,7 @@ Page({
 
   refreshPageState: function() {
     this.setData({
+      canUseDemoMode: dataSource.canUseDemoMode(),
       useMockData: dataSource.isMockMode(),
       dataSourceLabel: dataSource.getDataSourceLabel(),
       mockCredentialsHint: getMockCredentialsHint(),
@@ -159,6 +161,12 @@ Page({
   },
 
   handleDataSourceChange: function(event) {
+    if (!dataSource.canUseDemoMode()) {
+      dataSource.setDataSourceMode(dataSource.DATA_SOURCE_MODES.remote)
+      this.refreshPageState()
+      return
+    }
+
     const useMockData = !!event.detail.value
     dataSource.setDataSourceMode(useMockData ? dataSource.DATA_SOURCE_MODES.mock : dataSource.DATA_SOURCE_MODES.remote)
     auth.clearSession()

--- a/pages/settings/settings.wxml
+++ b/pages/settings/settings.wxml
@@ -1,21 +1,23 @@
 <view class="page__bd {{themeClass}}" style="{{fontStyle}}">
   <view class="weui-toptips weui-toptips_warn" wx:if="{{errorMessage}}">{{errorMessage}}</view>
 
-  <view class="weui-cells__title">{{t.dataSourceTitle}}</view>
-  <view class="weui-cells weui-cells_after-title">
-    <view class="weui-cell weui-cell_switch">
-      <view class="weui-cell__bd">{{t.useMockData}}</view>
-      <view class="weui-cell__ft">
-        <switch checked="{{useMockData}}" bindchange="handleDataSourceChange" />
+  <block wx:if="{{canUseDemoMode}}">
+    <view class="weui-cells__title">{{t.dataSourceTitle}}</view>
+    <view class="weui-cells weui-cells_after-title">
+      <view class="weui-cell weui-cell_switch">
+        <view class="weui-cell__bd">{{t.useMockData}}</view>
+        <view class="weui-cell__ft">
+          <switch checked="{{useMockData}}" bindchange="handleDataSourceChange" />
+        </view>
+      </view>
+      <view class="weui-cell">
+        <view class="weui-cell__bd">{{t.currentMode}}</view>
+        <view class="weui-cell__ft">{{dataSourceLabel}}</view>
       </view>
     </view>
-    <view class="weui-cell">
-      <view class="weui-cell__bd">{{t.currentMode}}</view>
-      <view class="weui-cell__ft">{{dataSourceLabel}}</view>
-    </view>
-  </view>
 
-  <text wx:if="{{useMockData}}" class="mock_hint">{{mockCredentialsHint}}</text>
+    <text wx:if="{{useMockData}}" class="mock_hint">{{mockCredentialsHint}}</text>
+  </block>
 
   <view class="weui-cells__title">{{t.campusCredentialTitle}}</view>
   <view class="credential_summary">

--- a/services/data-source.js
+++ b/services/data-source.js
@@ -1,12 +1,21 @@
 const storageKeys = require('../constants/storage.js')
 const i18n = require('../utils/i18n.js')
+const config = require('../config/index.js')
 
 const DATA_SOURCE_MODES = {
   remote: 'remote',
   mock: 'mock'
 }
 
+function canUseDemoMode() {
+  return !!config.allowRuntimeDebugOptions
+}
+
 function getDataSourceMode() {
+  if (!canUseDemoMode()) {
+    return DATA_SOURCE_MODES.remote
+  }
+
   try {
     const mode = wx.getStorageSync(storageKeys.dataSourceMode)
     if (mode === DATA_SOURCE_MODES.mock || mode === DATA_SOURCE_MODES.remote) {
@@ -21,9 +30,15 @@ function getDataSourceMode() {
 
 function setDataSourceMode(mode) {
   const nextMode =
-    mode === DATA_SOURCE_MODES.mock ? DATA_SOURCE_MODES.mock : DATA_SOURCE_MODES.remote
+    canUseDemoMode() && mode === DATA_SOURCE_MODES.mock
+      ? DATA_SOURCE_MODES.mock
+      : DATA_SOURCE_MODES.remote
   try {
-    wx.setStorageSync(storageKeys.dataSourceMode, nextMode)
+    if (!canUseDemoMode() && wx.removeStorageSync) {
+      wx.removeStorageSync(storageKeys.dataSourceMode)
+    } else {
+      wx.setStorageSync(storageKeys.dataSourceMode, nextMode)
+    }
   } catch (error) {
     // Ignore data source storage write failures.
   }
@@ -44,6 +59,7 @@ function getDataSourceLabel() {
 
 module.exports = {
   DATA_SOURCE_MODES,
+  canUseDemoMode,
   getDataSourceMode,
   setDataSourceMode,
   toggleDataSourceMode,

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -38,6 +38,7 @@ test('develop in devtools uses localhost resource domain', function () {
 
   assert.equal(config.currentEnv, 'dev')
   assert.equal(config.resourceDomain, 'http://localhost:8080/')
+  assert.equal(config.allowRuntimeDebugOptions, true)
 })
 
 test('develop on real device falls back to staging domain', function () {
@@ -70,6 +71,7 @@ test('release runtime uses production domain', function () {
 
   assert.equal(config.currentEnv, 'prod')
   assert.equal(config.resourceDomain, 'https://gdeiassistant.cn/')
+  assert.equal(config.allowRuntimeDebugOptions, false)
 })
 
 test('node staging environment resolves to staging config', function () {

--- a/tests/data-source.test.js
+++ b/tests/data-source.test.js
@@ -1,0 +1,66 @@
+const path = require('node:path')
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { clearModule } = require('./helpers/module.js')
+
+const ROOT = path.resolve(__dirname, '..')
+const CONFIG_MODULE = path.join(ROOT, 'config/index.js')
+const DATA_SOURCE_MODULE = path.join(ROOT, 'services/data-source.js')
+const STORAGE_MODULE = path.join(ROOT, 'constants/storage.js')
+
+function loadDataSource(envVersion, initialStorage) {
+  const storage = Object.assign({}, initialStorage)
+  const storageKeys = require(STORAGE_MODULE)
+
+  delete process.env.NODE_ENV
+  global.wx = {
+    getAccountInfoSync() {
+      return { miniProgram: { envVersion } }
+    },
+    getStorageSync(key) {
+      return storage[key]
+    },
+    setStorageSync(key, value) {
+      storage[key] = value
+    },
+    removeStorageSync(key) {
+      delete storage[key]
+    }
+  }
+
+  clearModule(CONFIG_MODULE)
+  clearModule(DATA_SOURCE_MODULE)
+  return {
+    dataSource: require(DATA_SOURCE_MODULE),
+    storage,
+    storageKeys
+  }
+}
+
+test('release runtime forces remote data source even when mock was stored', function () {
+  const { dataSource, storage, storageKeys } = loadDataSource('release', {
+    dataSourceMode: 'mock'
+  })
+
+  assert.equal(dataSource.canUseDemoMode(), false)
+  assert.equal(dataSource.getDataSourceMode(), dataSource.DATA_SOURCE_MODES.remote)
+  assert.equal(dataSource.isMockMode(), false)
+  assert.equal(
+    dataSource.setDataSourceMode(dataSource.DATA_SOURCE_MODES.mock),
+    dataSource.DATA_SOURCE_MODES.remote
+  )
+  assert.equal(storage[storageKeys.dataSourceMode], undefined)
+})
+
+test('develop runtime can opt into mock data source', function () {
+  const { dataSource, storage, storageKeys } = loadDataSource('develop')
+
+  assert.equal(dataSource.canUseDemoMode(), true)
+  assert.equal(
+    dataSource.setDataSourceMode(dataSource.DATA_SOURCE_MODES.mock),
+    dataSource.DATA_SOURCE_MODES.mock
+  )
+  assert.equal(storage[storageKeys.dataSourceMode], dataSource.DATA_SOURCE_MODES.mock)
+  assert.equal(dataSource.isMockMode(), true)
+})

--- a/tests/login-consent.test.js
+++ b/tests/login-consent.test.js
@@ -19,6 +19,7 @@ function setupWxRuntime() {
   const calls = {
     noActionModal: [],
     redirectTo: [],
+    showModal: [],
     showNavigationBarLoading: 0,
     hideNavigationBarLoading: 0
   }
@@ -41,6 +42,9 @@ function setupWxRuntime() {
     },
     redirectTo(options) {
       calls.redirectTo.push(options)
+    },
+    showModal(options) {
+      calls.showModal.push(options)
     },
     setNavigationBarTitle() {},
     getAccountInfoSync() {
@@ -106,6 +110,9 @@ function stubCommon(loginSpy, modalCalls) {
   })
   stubModule(path.join(ROOT, 'services/data-source.js'), {
     DATA_SOURCE_MODES: { remote: 'remote', mock: 'mock' },
+    canUseDemoMode() {
+      return true
+    },
     isMockMode() {
       return false
     },
@@ -127,6 +134,9 @@ function stubCommon(loginSpy, modalCalls) {
         'login.passwordPlaceholder': '请输入校园网密码',
         'login.button': '登录',
         'login.campusCredentialConsentText': 'consent text',
+        'login.campusCredentialConsentSummary': 'consent summary',
+        'login.campusCredentialConsentDetailAction': '查看详情',
+        'login.campusCredentialConsentDetailTitle': '授权说明',
         'login.campusCredentialConsentRequired': '请先勾选校园凭证单独授权后再登录',
         'login.debugSettings': '数据源设置',
         'login.useMockData': '使用演示数据',
@@ -172,6 +182,24 @@ test('login blocks submit when campus credential consent is not checked', async 
   assert.equal(loginCallCount, 0)
   assert.equal(runtime.calls.noActionModal.length, 1)
   assert.equal(runtime.calls.noActionModal[0].content, '请先勾选校园凭证单独授权后再登录')
+})
+
+test('login shows full campus credential consent detail on request', async function () {
+  const runtime = setupWxRuntime()
+  stubCommon(function () {
+    return Promise.resolve({ success: true, data: { token: 'token' } })
+  }, runtime.calls.noActionModal)
+
+  const page = createPageInstance(loadPage())
+  page.onLoad()
+  await waitForSettled()
+
+  page.showCampusCredentialConsentDetail()
+
+  assert.equal(runtime.calls.showModal.length, 1)
+  assert.equal(runtime.calls.showModal[0].title, '授权说明')
+  assert.equal(runtime.calls.showModal[0].content, 'consent text')
+  assert.equal(runtime.calls.showModal[0].showCancel, false)
 })
 
 test('login sends campus credential consent metadata when checked', async function () {

--- a/tests/mock-ui-smoke.test.js
+++ b/tests/mock-ui-smoke.test.js
@@ -341,7 +341,9 @@ test('appearance page labels traditional Chinese variants as Hong Kong/Macau and
   const page = createPageInstance(pageConfig, runtime.calls)
   page.onLoad()
 
-  const labelsByCode = Object.fromEntries(page.data.locales.map((locale) => [locale.code, locale.label]))
+  const labelsByCode = Object.fromEntries(
+    page.data.locales.map((locale) => [locale.code, locale.label])
+  )
   assert.equal(labelsByCode['zh-HK'], '繁體中文（港澳）')
   assert.equal(labelsByCode['zh-TW'], '繁體中文（台灣）')
   assert.ok(!page.data.locales.some((locale) => locale.label === '繁體中文（香港）'))

--- a/tests/mock-ui-smoke.test.js
+++ b/tests/mock-ui-smoke.test.js
@@ -10,6 +10,7 @@ const LOGIN_PAGE_MODULE = path.join(ROOT, 'pages/login/login.js')
 const INDEX_PAGE_MODULE = path.join(ROOT, 'pages/index/index.js')
 const NEWS_PAGE_MODULE = path.join(ROOT, 'pages/news/news.js')
 const COMMUNITY_LIST_PAGE_MODULE = path.join(ROOT, 'pages/communityList/communityList.js')
+const APPEARANCE_PAGE_MODULE = path.join(ROOT, 'pages/appearance/appearance.js')
 const STORAGE_MODULE = path.join(ROOT, 'constants/storage.js')
 
 function waitForSettled() {
@@ -93,6 +94,9 @@ function stubCommonModules(options) {
       'login.passwordPlaceholder': '请输入密码',
       'login.button': '登录',
       'login.campusCredentialConsentText': 'consent text',
+      'login.campusCredentialConsentSummary': 'consent summary',
+      'login.campusCredentialConsentDetailAction': '查看详情',
+      'login.campusCredentialConsentDetailTitle': '授权说明',
       'login.campusCredentialConsentRequired': '请先勾选校园凭证单独授权后再登录',
       'login.debugSettings': '数据源设置',
       'login.useMockData': '使用演示数据',
@@ -139,6 +143,10 @@ function stubCommonModules(options) {
   )
 
   stubModule(path.join(ROOT, 'utils/i18n.js'), {
+    getCurrentLocale() {
+      return 'zh-CN'
+    },
+    setLocale() {},
     t(key) {
       return Object.prototype.hasOwnProperty.call(translations, key) ? translations[key] : key
     },
@@ -252,6 +260,9 @@ test('mock UI smoke covers login page bootstrap and submit flow', async function
 
   stubModule(path.join(ROOT, 'services/data-source.js'), {
     DATA_SOURCE_MODES: { remote: 'remote', mock: 'mock' },
+    canUseDemoMode() {
+      return true
+    },
     isMockMode() {
       return true
     },
@@ -292,6 +303,48 @@ test('mock UI smoke covers login page bootstrap and submit flow', async function
   assert.equal(runtime.calls.redirectTo[0].url, '../index/index')
   assert.equal(runtime.calls.showNavigationBarLoading, 1)
   assert.equal(runtime.calls.hideNavigationBarLoading, 1)
+})
+
+test('appearance page labels traditional Chinese variants as Hong Kong/Macau and Taiwan', function () {
+  const runtime = setupWxRuntime()
+  stubCommonModules({
+    translations: {
+      'appearance.title': '外观',
+      'appearance.theme.label': '主题',
+      'appearance.theme.system': '跟随系统',
+      'appearance.theme.light': '浅色',
+      'appearance.theme.dark': '深色',
+      'appearance.font.label': '字体大小',
+      'appearance.font.small': '小',
+      'appearance.font.standard': '标准',
+      'appearance.font.large': '大',
+      'appearance.font.xlarge': '特大',
+      'appearance.font.preview': '预览',
+      'appearance.language.label': '语言'
+    }
+  })
+  stubModule(path.join(ROOT, 'utils/theme.js'), {
+    FONT_SCALES: [0.85, 1, 1.15, 1.3],
+    applyTheme() {},
+    getThemeMode() {
+      return 'system'
+    },
+    getFontScaleStep() {
+      return 1
+    },
+    buildFontStyle() {
+      return ''
+    }
+  })
+
+  const pageConfig = loadPage(APPEARANCE_PAGE_MODULE)
+  const page = createPageInstance(pageConfig, runtime.calls)
+  page.onLoad()
+
+  const labelsByCode = Object.fromEntries(page.data.locales.map((locale) => [locale.code, locale.label]))
+  assert.equal(labelsByCode['zh-HK'], '繁體中文（港澳）')
+  assert.equal(labelsByCode['zh-TW'], '繁體中文（台灣）')
+  assert.ok(!page.data.locales.some((locale) => locale.label === '繁體中文（香港）'))
 })
 
 test('mock UI smoke covers index page profile, inbox badge and feature actions', async function () {
@@ -350,6 +403,9 @@ test('mock UI smoke covers index page profile, inbox badge and feature actions',
   })
 
   stubModule(path.join(ROOT, 'services/data-source.js'), {
+    canUseDemoMode() {
+      return true
+    },
     getDataSourceLabel() {
       return '模拟数据'
     }

--- a/tests/settings-campus-credential.test.js
+++ b/tests/settings-campus-credential.test.js
@@ -100,6 +100,9 @@ function stubCommon(calls, apiStub, tokenValue) {
   })
   stubModule(path.join(ROOT, 'services/data-source.js'), {
     DATA_SOURCE_MODES: { remote: 'remote', mock: 'mock' },
+    canUseDemoMode() {
+      return true
+    },
     isMockMode() {
       return false
     },


### PR DESCRIPTION
## Summary
- force release builds to use the remote data source and hide demo controls
- shorten campus credential consent copy with a details modal
- rename the traditional Chinese Hong Kong option to Hong Kong/Macau

## Verification
- npm test
- npm run smoke
- npm run lint