### PR TITLE
Add WeChat deploy workflow

### DIFF
--- a/.github/workflows/wechat-deploy.yml
+++ b/.github/workflows/wechat-deploy.yml
@@ -1,0 +1,60 @@
+name: WeChat Mini Program Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Upload version shown in WeChat Mini Program admin
+        required: true
+        type: string
+      description:
+        description: Upload description
+        required: true
+        type: string
+      robot:
+        description: WeChat upload robot number
+        required: false
+        default: "1"
+        type: string
+
+jobs:
+  upload:
+    name: Upload Mini Program
+    runs-on: ubuntu-latest
+    environment: wechat-production
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run release checks
+        run: |
+          npm run lint
+          npm run format:check
+          npm test
+          npm run smoke
+
+      - name: Install WeChat CI uploader
+        run: npm install --no-save --no-package-lock miniprogram-ci@2.1.31
+
+      - name: Upload to WeChat Mini Program
+        env:
+          WECHAT_APP_ID: ${{ secrets.WECHAT_APP_ID }}
+          WECHAT_PRIVATE_KEY: ${{ secrets.WECHAT_PRIVATE_KEY }}
+          WECHAT_PRIVATE_KEY_BASE64: ${{ secrets.WECHAT_PRIVATE_KEY_BASE64 }}
+          WECHAT_UPLOAD_VERSION: ${{ inputs.version }}
+          WECHAT_UPLOAD_DESC: ${{ inputs.description }}
+          WECHAT_UPLOAD_ROBOT: ${{ inputs.robot }}
+        run: node scripts/deploy-wechat.js

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,25 @@
+# Deployment
+
+## WeChat Mini Program
+
+Use the `WeChat Mini Program Deploy` GitHub Actions workflow to upload a version
+to the WeChat Mini Program admin backend.
+
+Required environment or repository secrets:
+
+- `WECHAT_PRIVATE_KEY` or `WECHAT_PRIVATE_KEY_BASE64`: upload private key from
+  the WeChat Mini Program admin console.
+
+Optional secrets:
+
+- `WECHAT_APP_ID`: overrides `project.config.json` when present.
+
+Workflow inputs:
+
+- `version`: version string shown in WeChat Mini Program admin.
+- `description`: upload description.
+- `robot`: WeChat upload robot number, defaults to `1`.
+
+The workflow runs lint, formatting checks, tests, and smoke checks before
+uploading. It installs `miniprogram-ci@2.1.31` only inside the deployment job so
+the development dependency tree stays small.

--- a/scripts/deploy-wechat.js
+++ b/scripts/deploy-wechat.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function requireEnv(name) {
+  const value = process.env[name]
+  if (!value || !value.trim()) {
+    throw new Error(`${name} is required`)
+  }
+  return value.trim()
+}
+
+function resolvePrivateKey() {
+  if (process.env.WECHAT_PRIVATE_KEY_BASE64) {
+    return Buffer.from(process.env.WECHAT_PRIVATE_KEY_BASE64, 'base64').toString('utf8')
+  }
+
+  if (process.env.WECHAT_PRIVATE_KEY) {
+    const raw = process.env.WECHAT_PRIVATE_KEY
+    return raw.includes('\\n') ? raw.replace(/\\n/g, '\n') : raw
+  }
+
+  throw new Error('WECHAT_PRIVATE_KEY or WECHAT_PRIVATE_KEY_BASE64 is required')
+}
+
+async function main() {
+  const ci = require('miniprogram-ci')
+  const projectRoot = process.cwd()
+  const projectConfig = readJson(path.join(projectRoot, 'project.config.json'))
+  const appid = process.env.WECHAT_APP_ID || projectConfig.appid
+  const version = requireEnv('WECHAT_UPLOAD_VERSION')
+  const desc = process.env.WECHAT_UPLOAD_DESC || `GitHub Actions upload ${version}`
+  const robot = Number.parseInt(process.env.WECHAT_UPLOAD_ROBOT || '1', 10)
+  const privateKeyPath = path.join(os.tmpdir(), `gdeiassistant-wechat-key-${process.pid}.key`)
+
+  if (!appid) {
+    throw new Error('WECHAT_APP_ID or project.config.json appid is required')
+  }
+  if (!Number.isInteger(robot) || robot < 1 || robot > 30) {
+    throw new Error('WECHAT_UPLOAD_ROBOT must be an integer from 1 to 30')
+  }
+
+  fs.writeFileSync(privateKeyPath, resolvePrivateKey(), { mode: 0o600 })
+
+  try {
+    const project = new ci.Project({
+      appid,
+      type: 'miniProgram',
+      projectPath: projectRoot,
+      privateKeyPath,
+      ignores: ['node_modules/**/*', '.git/**/*']
+    })
+
+    await ci.upload({
+      project,
+      version,
+      desc,
+      robot,
+      setting: {
+        es6: !!projectConfig.setting?.es6,
+        minify: !!projectConfig.setting?.minified,
+        minifyJS: !!projectConfig.setting?.minified,
+        minifyWXML: !!projectConfig.setting?.minifyWXML,
+        minifyWXSS: !!projectConfig.setting?.minifyWXSS,
+        autoPrefixWXSS: !!projectConfig.setting?.postcss
+      },
+      onProgressUpdate: console.log
+    })
+  } finally {
+    fs.rmSync(privateKeyPath, { force: true })
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- Add a manual GitHub Actions deployment workflow for WeChat Mini Program uploads.
- Add `scripts/deploy-wechat.js` to upload through `miniprogram-ci` using repository or environment secrets.
- Document required upload credentials and workflow inputs.

## Validation

- `node --check scripts/deploy-wechat.js`
- YAML parsed with Node `yaml`
- `git diff --check`
- `npm ci`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run smoke`

## Notes

The workflow requires `WECHAT_PRIVATE_KEY` or `WECHAT_PRIVATE_KEY_BASE64` before it can upload to the WeChat Mini Program admin backend.
