### PR TITLE
Harden Dependabot major update detection

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -92,13 +92,13 @@ jobs:
             process.exit(0)
           }
           
-          const versionPairs = [...`${pr.title}\n${pr.body || ''}`.matchAll(/from\s+v?(\d+)\.(\d+)\.(\d+)(?:[-+][^\s<),]*)?\s+to\s+v?(\d+)\.(\d+)\.(\d+)(?:[-+][^\s<),]*)?/gi)]
+          const versionPairs = [...`${pr.title}\n${pr.body || ''}`.matchAll(/from\s+v?(\d+)(?:\.\d+){0,2}(?:[-+][^\s<),]*)?\s+to\s+v?(\d+)(?:\.\d+){0,2}(?:[-+][^\s<),]*)?/gi)]
           if (versionPairs.length === 0) {
-            log(`skip PR #${prNumber}: no semver from/to pairs found; fail closed`)
+            log(`skip PR #${prNumber}: no semver-like from/to pairs found; fail closed`)
             process.exit(0)
           }
-          if (versionPairs.some((match) => match[1] !== match[4])) {
-            log(`skip PR #${prNumber}: semver-major update detected`)
+          if (versionPairs.some((match) => match[1] !== match[2])) {
+            log(`skip PR #${prNumber}: major update detected`)
             process.exit(0)
           }
           


### PR DESCRIPTION
## Summary
- Harden Dependabot auto-merge major-version detection.
- Treat `from 6 to 7`, `from v6 to v7`, `from 1.2 to 2.0`, and `from 1.2.3 to 2.0.0` as major updates.
- Keep fail-closed behavior for unclassified Dependabot PRs.

## Validation
- YAML parsed with Ruby `YAML.load_file`.
- Embedded JavaScript passed `node --check`.
- `git diff --check` passed.
